### PR TITLE
chore: biome ts tsx formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Replace with the commit hash of the dedicated Biome formatting commit.
+REPLACE_WITH_BIOME_FORMAT_COMMIT_HASH

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,1 @@
-# Replace with the commit hash of the dedicated Biome formatting commit.
-REPLACE_WITH_BIOME_FORMAT_COMMIT_HASH
+c4cc3d13ea0f65337196e57bb3615a8d8e6e1ef1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Install Biome
+        run: bun install -g @biomejs/biome
+
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         pass_filenames: false
       - id: biome-format
         name: Biome format check
-        entry: bash -c 'cd configurator && bun run format:check'
+        entry: bash -c 'cd configurator && bun run format'
         language: system
         files: ^configurator/.*\.(ts|tsx)$
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,9 @@ repos:
         language: script
         files: ^models/.*\.scad$
         pass_filenames: false
+      - id: biome-format
+        name: Biome format check
+        entry: bash -c 'cd configurator && npx @biomejs/biome format --check'
+        language: system
+        files: ^configurator/.*\.(ts|tsx)$
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         pass_filenames: false
       - id: biome-format
         name: Biome format check
-        entry: bash -c 'cd configurator && npx @biomejs/biome format --check'
+        entry: bash -c 'cd configurator && bun run format:check'
         language: system
         files: ^configurator/.*\.(ts|tsx)$
         pass_filenames: false

--- a/configurator/biome.json
+++ b/configurator/biome.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": false
+  },
+  "files": {
+    "includes": ["src/**/*.ts", "src/**/*.tsx", "e2e/**/*.ts", "e2e/**/*.tsx", "scripts/**/*.ts", "scripts/**/*.tsx"]
+  }
+}

--- a/configurator/bun.lock
+++ b/configurator/bun.lock
@@ -13,6 +13,7 @@
         "three-mesh-bvh": "^0.9.9",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.10",
         "@playwright/test": "^1.58.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -23,6 +24,24 @@
   },
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
 
     "@mediapipe/tasks-vision": ["@mediapipe/tasks-vision@0.10.17", "", {}, "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="],
 

--- a/configurator/e2e/assembly-bom.spec.ts
+++ b/configurator/e2e/assembly-bom.spec.ts
@@ -1,24 +1,16 @@
 import { test, expect, clickCatalogItem, getBBox, waitForMesh, waitForBOM } from "./fixtures";
 
 test.describe("No geometry below ground (Y=0)", () => {
-  test("connector-3d6w can be placed at Y=0 (no collision system)", async ({
-    appPage: page,
-  }) => {
+  test("connector-3d6w can be placed at Y=0 (no collision system)", async ({ appPage: page }) => {
     await page.evaluate(() => (window as any).__assembly.clear());
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 0, 0])
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 0, 0]));
     // No collision system — placement always succeeds
     expect(id).not.toBeNull();
   });
 
-  test("connector-3d6w at Y=1 is allowed (arm reaches Y=0)", async ({
-    appPage: page,
-  }) => {
+  test("connector-3d6w at Y=1 is allowed (arm reaches Y=0)", async ({ appPage: page }) => {
     await page.evaluate(() => (window as any).__assembly.clear());
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0])
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0]));
     expect(id).not.toBeNull();
     await waitForMesh(page, `placed-${id}`);
 
@@ -27,13 +19,9 @@ test.describe("No geometry below ground (Y=0)", () => {
     expect(bbox!.minY).toBeGreaterThanOrEqual(-0.1);
   });
 
-  test("support at ground level has minY >= 0", async ({
-    appPage: page,
-  }) => {
+  test("support at ground level has minY >= 0", async ({ appPage: page }) => {
     await page.evaluate(() => (window as any).__assembly.clear());
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 0, 0])
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("support-3u", [0, 0, 0]));
     expect(id).not.toBeNull();
     await waitForMesh(page, `placed-${id}`);
 
@@ -42,13 +30,9 @@ test.describe("No geometry below ground (Y=0)", () => {
     expect(bbox!.minY).toBeGreaterThanOrEqual(-0.1);
   });
 
-  test("x-oriented support at ground level has minY >= 0", async ({
-    appPage: page,
-  }) => {
+  test("x-oriented support at ground level has minY >= 0", async ({ appPage: page }) => {
     await page.evaluate(() => (window as any).__assembly.clear());
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-5u", [0, 0, 0], [0, 0, 0], "x")
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("support-5u", [0, 0, 0], [0, 0, 0], "x"));
     expect(id).not.toBeNull();
     await waitForMesh(page, `placed-${id}`);
 
@@ -57,25 +41,17 @@ test.describe("No geometry below ground (Y=0)", () => {
     expect(bbox!.minY).toBeGreaterThanOrEqual(-0.1);
   });
 
-  test("rotated connector with arm below ground is allowed (no collision)", async ({
-    appPage: page,
-  }) => {
+  test("rotated connector with arm below ground is allowed (no collision)", async ({ appPage: page }) => {
     await page.evaluate(() => (window as any).__assembly.clear());
     // connector-2d4w rotated 90° around X: a horizontal arm becomes -Y
     // No collision system — placement always succeeds
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-2d4w", [0, 0, 0], [90, 0, 0])
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("connector-2d4w", [0, 0, 0], [90, 0, 0]));
     expect(id).not.toBeNull();
   });
 
-  test("connector-3d5w (no -Y arm) can be placed at Y=0", async ({
-    appPage: page,
-  }) => {
+  test("connector-3d5w (no -Y arm) can be placed at Y=0", async ({ appPage: page }) => {
     await page.evaluate(() => (window as any).__assembly.clear());
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d5w", [0, 0, 0])
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("connector-3d5w", [0, 0, 0]));
     expect(id).not.toBeNull();
   });
 });
@@ -86,9 +62,7 @@ test.describe("Place parts and BOM", () => {
   });
 
   test("place connector and verify BOM", async ({ appPage: page }) => {
-    const placed1 = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0])
-    );
+    const placed1 = await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0]));
     expect(placed1).not.toBeNull();
     await waitForBOM(page, 1);
 
@@ -105,9 +79,7 @@ test.describe("Place parts and BOM", () => {
     expect(bom1[0].qty).toBe("1");
   });
 
-  test("place two connectors updates BOM quantity", async ({
-    appPage: page,
-  }) => {
+  test("place two connectors updates BOM quantity", async ({ appPage: page }) => {
     await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.addPart("connector-3d6w", [0, 1, 0]);
@@ -126,9 +98,7 @@ test.describe("Place parts and BOM", () => {
     expect(bom.some((r) => r.qty === "2")).toBe(true);
   });
 
-  test("place mixed parts shows multiple BOM rows", async ({
-    appPage: page,
-  }) => {
+  test("place mixed parts shows multiple BOM rows", async ({ appPage: page }) => {
     await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.addPart("connector-3d6w", [0, 1, 0]);
@@ -158,15 +128,11 @@ test.describe("Place parts and BOM", () => {
     });
     await waitForBOM(page, 2);
 
-    const totalText = await page.evaluate(
-      () => document.querySelector(".bom-total")?.textContent?.trim() ?? ""
-    );
+    const totalText = await page.evaluate(() => document.querySelector(".bom-total")?.textContent?.trim() ?? "");
     expect(totalText).toContain("parts");
   });
 
-  test("BOM lock pins with oriented supports", async ({
-    appPage: page,
-  }) => {
+  test("BOM lock pins with oriented supports", async ({ appPage: page }) => {
     await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.addPart("connector-3d6w", [0, 1, 0]);
@@ -189,13 +155,9 @@ test.describe("Place parts and BOM", () => {
 test.describe("Overlapping placement (no collision)", () => {
   test("can place on occupied position", async ({ appPage: page }) => {
     await page.evaluate(() => (window as any).__assembly.clear());
-    await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0])
-    );
+    await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0]));
 
-    const overlap = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-2d2w", [0, 1, 0])
-    );
+    const overlap = await page.evaluate(() => (window as any).__assembly.addPart("connector-2d2w", [0, 1, 0]));
     expect(overlap).not.toBeNull();
   });
 });
@@ -219,10 +181,7 @@ test.describe("Clear All", () => {
         }
       }
     });
-    await page.waitForFunction(
-      () => (window as any).__assembly.getAllParts().length === 0,
-      { timeout: 3_000 },
-    );
+    await page.waitForFunction(() => (window as any).__assembly.getAllParts().length === 0, { timeout: 3_000 });
 
     const afterClear = await page.evaluate(() => {
       const emptyMsg = document.querySelector(".bom-empty");
@@ -248,9 +207,7 @@ test.describe("Clear All", () => {
       a.clear();
     });
 
-    const result = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-2d4w", [0, 0, 0])
-    );
+    const result = await page.evaluate(() => (window as any).__assembly.addPart("connector-2d4w", [0, 0, 0]));
     expect(result).not.toBeNull();
   });
 });
@@ -291,14 +248,9 @@ test.describe("Placed part orientation matches ghost", () => {
 
     // Exit and place via API
     await page.keyboard.press("Escape");
-    await page.waitForFunction(
-      () => !document.querySelector(".catalog-item.active"),
-      { timeout: 3_000 },
-    );
+    await page.waitForFunction(() => !document.querySelector(".catalog-item.active"), { timeout: 3_000 });
 
-    const supportId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 0, 0])
-    );
+    const supportId = await page.evaluate(() => (window as any).__assembly.addPart("support-3u", [0, 0, 0]));
     expect(supportId).not.toBeNull();
 
     await waitForMesh(page, `placed-${supportId}`);
@@ -318,8 +270,7 @@ test.describe("Placed part orientation matches ghost", () => {
             ? "X"
             : "Z";
       const placedTallAxis =
-        placedBBox.sizeY > placedBBox.sizeX &&
-        placedBBox.sizeY > placedBBox.sizeZ
+        placedBBox.sizeY > placedBBox.sizeX && placedBBox.sizeY > placedBBox.sizeZ
           ? "Y"
           : placedBBox.sizeX > placedBBox.sizeZ
             ? "X"

--- a/configurator/e2e/auto-rotation.spec.ts
+++ b/configurator/e2e/auto-rotation.spec.ts
@@ -5,9 +5,7 @@ test.describe("Auto-rotation for connector snapping", () => {
     await page.evaluate(() => (window as any).__assembly.clear());
   });
 
-  test("L-shape corner: 2D-2W rotates to face both supports", async ({
-    appPage: page,
-  }) => {
+  test("L-shape corner: 2D-2W rotates to face both supports", async ({ appPage: page }) => {
     // Place a Y-support at [0,0,0] (cells [0,0,0]..[0,2,0])
     // and an X-support starting at [0,3,0] (cells [0,3,0],[1,3,0],[2,3,0])
     // The connector snap point at [0,3,0] should see:
@@ -62,9 +60,7 @@ test.describe("Auto-rotation for connector snapping", () => {
     expect(armsCovered).toEqual([90, 0, 0]);
   });
 
-  test("3-way junction: 3D-3W rotates to face three supports", async ({
-    appPage: page,
-  }) => {
+  test("3-way junction: 3D-3W rotates to face three supports", async ({ appPage: page }) => {
     // Place three supports meeting near [0,3,0]:
     // Y-support: [0,0,0]..[0,2,0], top endpoint [0,2,0] outward +y → connector at [0,3,0], needed -y
     // X-support: [1,3,0]..[3,3,0], left endpoint [1,3,0] outward -x → connector at [0,3,0], needed +x
@@ -108,9 +104,7 @@ test.describe("Auto-rotation for connector snapping", () => {
     expect(result.autoRotation).toBeDefined();
   });
 
-  test("single support endpoint: 1D-1W rotates arm toward support", async ({
-    appPage: page,
-  }) => {
+  test("single support endpoint: 1D-1W rotates arm toward support", async ({ appPage: page }) => {
     // Y-support: [0,0,0]..[0,2,0], top endpoint outward +y → connector at [0,3,0], needed -y
     // 1D-1W base arm: [+z]. Need rotation to get -y.
     // Rotation [90,0,0]: +z→-y. ✓ Total steps = 1, simplest.
@@ -134,9 +128,7 @@ test.describe("Auto-rotation for connector snapping", () => {
     expect(result.autoRotation).toEqual([90, 0, 0]);
   });
 
-  test("no supports nearby: returns fallback rotation", async ({
-    appPage: page,
-  }) => {
+  test("no supports nearby: returns fallback rotation", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const snap = (window as any).__snap;
       const fallback = [90, 0, 0] as [number, number, number];
@@ -147,9 +139,7 @@ test.describe("Auto-rotation for connector snapping", () => {
     expect(result).toEqual([90, 0, 0]);
   });
 
-  test("6-way connector covers all directions at 6-support junction", async ({
-    appPage: page,
-  }) => {
+  test("6-way connector covers all directions at 6-support junction", async ({ appPage: page }) => {
     // 3D-6W has all 6 arms, so any rotation covers all directions.
     // Auto-rotation should prefer [0,0,0] (simplest).
     const result = await page.evaluate(() => {

--- a/configurator/e2e/autorotate-fixture.spec.ts
+++ b/configurator/e2e/autorotate-fixture.spec.ts
@@ -19,9 +19,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
     // Load fixture, filtering out custom parts that won't exist in test env
     const filteredFixture = {
       ...fixtureData,
-      parts: fixtureData.parts.filter(
-        (p: { type: string }) => !p.type.startsWith("custom-")
-      ),
+      parts: fixtureData.parts.filter((p: { type: string }) => !p.type.startsWith("custom-")),
     };
     await page.evaluate((data) => {
       const a = (window as any).__assembly;
@@ -29,9 +27,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
     }, filteredFixture);
   });
 
-  test("connector snaps to correct Y at junction [0,15,-3]", async ({
-    appPage: page,
-  }) => {
+  test("connector snaps to correct Y at junction [0,15,-3]", async ({ appPage: page }) => {
     // The junction at [0, 15, -3] has 4 support endpoints converging:
     // - support-13u at [0,2,-3] y-oriented: top endpoint [0,14,-3], outward +y
     // - support-18u at [0,15,-2] z-oriented: first endpoint [0,15,-2], outward -z
@@ -61,9 +57,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
     expect(result.position).toEqual([0, 15, -3]);
   });
 
-  test("auto-rotation covers all 4 needed directions at junction", async ({
-    appPage: page,
-  }) => {
+  test("auto-rotation covers all 4 needed directions at junction", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const snap = (window as any).__snap;
@@ -95,9 +89,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
       if (!gridUtils) return null;
 
       const baseArms = ["+z", "-z", "+x", "+y"];
-      return baseArms.map((arm: string) =>
-        gridUtils.rotateDirection(arm, rotation)
-      );
+      return baseArms.map((arm: string) => gridUtils.rotateDirection(arm, rotation));
     }, result.autoRotation);
 
     if (armsCovered) {
@@ -108,9 +100,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
     }
   });
 
-  test("snap position is not affected by ground lift", async ({
-    appPage: page,
-  }) => {
+  test("snap position is not affected by ground lift", async ({ appPage: page }) => {
     // This test ensures the snap Y doesn't get inflated by computeGroundLift
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -140,9 +130,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
     }
   });
 
-  test("diagnostic: all snap candidates with positions and distances", async ({
-    appPage: page,
-  }) => {
+  test("diagnostic: all snap candidates with positions and distances", async ({ appPage: page }) => {
     // Diagnostic test: dump all snap candidates to understand what positions
     // are available and which one might win with different cursor/ray combos
     const result = await page.evaluate(() => {
@@ -151,9 +139,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
 
       // Use larger radius to see ALL possible snap positions
       const cursorGrid = [0, 0, -3] as [number, number, number];
-      const candidates = snap.findConnectorSnapPoints(
-        a, "connector-3d4w", cursorGrid, 50
-      );
+      const candidates = snap.findConnectorSnapPoints(a, "connector-3d4w", cursorGrid, 50);
 
       // Collect unique positions with their distances
       const posMap = new Map<string, { pos: number[]; distance: number; count: number; socketDirs: string[] }>();
@@ -190,9 +176,7 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
     expect(result.uniquePositions[0].pos).toEqual([0, 15, -3]);
   });
 
-  test("snap with ray from above selects correct Y position", async ({
-    appPage: page,
-  }) => {
+  test("snap with ray from above selects correct Y position", async ({ appPage: page }) => {
     // Simulate a camera ray looking downward at the junction
     // Camera is above and slightly behind, looking down at the junction
     const result = await page.evaluate(() => {
@@ -202,8 +186,8 @@ test.describe("Autorotate fixture: connector snap Y-height", () => {
       const cursorGrid = [0, 0, -3] as [number, number, number];
       // Simulate a ray from above pointing down (camera above the scene)
       const ray = {
-        origin: [0, 40, -3] as [number, number, number],  // above the scene
-        direction: [0, -1, 0] as [number, number, number],  // looking straight down
+        origin: [0, 40, -3] as [number, number, number], // above the scene
+        direction: [0, -1, 0] as [number, number, number], // looking straight down
       };
 
       const best = snap.findBestConnectorSnap(a, "connector-3d4w", cursorGrid, 3, ray);

--- a/configurator/e2e/bom-lockpins.spec.ts
+++ b/configurator/e2e/bom-lockpins.spec.ts
@@ -2,9 +2,7 @@ import { test, expect } from "./fixtures";
 import cuberack from "./fixtures/cuberack.json" with { type: "json" };
 
 test.describe("BOM lock pin calculation with cuberack fixture", () => {
-  test("cuberack has 24 lock pins needed (+ spare)", async ({
-    appPage: page,
-  }) => {
+  test("cuberack has 24 lock pins needed (+ spare)", async ({ appPage: page }) => {
     // Load the cuberack fixture (skip custom-stl-1 which won't resolve)
     await page.evaluate((data) => {
       const a = (window as any).__assembly;
@@ -22,9 +20,7 @@ test.describe("BOM lock pin calculation with cuberack fixture", () => {
       return a.getBOM();
     });
 
-    const lockPinEntry = bom.find(
-      (e: any) => e.category === "lockpin"
-    );
+    const lockPinEntry = bom.find((e: any) => e.category === "lockpin");
 
     expect(lockPinEntry).toBeTruthy();
     // 8 connectors × 3 arms each = 24 arms, all adjacent to supports

--- a/configurator/e2e/camera-views.spec.ts
+++ b/configurator/e2e/camera-views.spec.ts
@@ -31,11 +31,14 @@ test.describe("Camera views", () => {
   test("toggle switches to orthographic camera", async ({ appPage: page }) => {
     await page.click(".viewport-camera-toggle");
 
-    await page.waitForFunction(() => {
-      const camera = (window as any).__camera as any;
-      const label = document.querySelector(".viewport-camera-toggle")?.textContent ?? "";
-      return !!camera?.isOrthographicCamera && label.includes("ORTHO");
-    }, { timeout: 5_000 });
+    await page.waitForFunction(
+      () => {
+        const camera = (window as any).__camera as any;
+        const label = document.querySelector(".viewport-camera-toggle")?.textContent ?? "";
+        return !!camera?.isOrthographicCamera && label.includes("ORTHO");
+      },
+      { timeout: 5_000 },
+    );
 
     const result = await page.evaluate((key) => {
       const camera = (window as any).__camera as any;
@@ -56,11 +59,14 @@ test.describe("Camera views", () => {
     await page.reload();
     await waitForApp(page);
 
-    await page.waitForFunction(() => {
-      const camera = (window as any).__camera as any;
-      const label = document.querySelector(".viewport-camera-toggle")?.textContent ?? "";
-      return !!camera?.isOrthographicCamera && label.includes("ORTHO");
-    }, { timeout: 5_000 });
+    await page.waitForFunction(
+      () => {
+        const camera = (window as any).__camera as any;
+        const label = document.querySelector(".viewport-camera-toggle")?.textContent ?? "";
+        return !!camera?.isOrthographicCamera && label.includes("ORTHO");
+      },
+      { timeout: 5_000 },
+    );
 
     const persisted = await page.evaluate((key) => localStorage.getItem(key), CAMERA_MODE_STORAGE_KEY);
     expect(persisted).toBe("1");
@@ -71,11 +77,14 @@ test.describe("Camera views", () => {
     await page.waitForFunction(() => !!(window as any).__camera?.isOrthographicCamera, { timeout: 5_000 });
 
     await page.click(".viewport-camera-toggle");
-    await page.waitForFunction(() => {
-      const camera = (window as any).__camera as any;
-      const label = document.querySelector(".viewport-camera-toggle")?.textContent ?? "";
-      return !!camera?.isPerspectiveCamera && label.includes("PERSP");
-    }, { timeout: 5_000 });
+    await page.waitForFunction(
+      () => {
+        const camera = (window as any).__camera as any;
+        const label = document.querySelector(".viewport-camera-toggle")?.textContent ?? "";
+        return !!camera?.isPerspectiveCamera && label.includes("PERSP");
+      },
+      { timeout: 5_000 },
+    );
 
     const result = await page.evaluate((key) => {
       const camera = (window as any).__camera as any;

--- a/configurator/e2e/collision-detection.spec.ts
+++ b/configurator/e2e/collision-detection.spec.ts
@@ -7,24 +7,26 @@ test.describe("Collision detection", () => {
 
   // --- Grid-level collision (fast, synchronous) ---
 
-  test("two connectors at the same position are detected as colliding (grid)", async ({
-    appPage: page,
-  }) => {
+  test("two connectors at the same position are detected as colliding (grid)", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const id1 = a.addPart("connector-2d2w", [0, 0, 0]);
       const id2 = a.addPart("connector-2d2w", [0, 0, 0]);
       const { detectCollidingPartIds } = (window as any).__collision;
       const colliding = detectCollidingPartIds(a);
-      return { id1, id2, has1: colliding.has(id1), has2: colliding.has(id2), size: colliding.size };
+      return {
+        id1,
+        id2,
+        has1: colliding.has(id1),
+        has2: colliding.has(id2),
+        size: colliding.size,
+      };
     });
     expect(result.has1).toBe(true);
     expect(result.has2).toBe(true);
   });
 
-  test("two connectors far apart do NOT collide (grid)", async ({
-    appPage: page,
-  }) => {
+  test("two connectors far apart do NOT collide (grid)", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.addPart("connector-2d2w", [0, 0, 0]);
@@ -36,9 +38,7 @@ test.describe("Collision detection", () => {
     expect(result).toBe(0);
   });
 
-  test("PT connector and support at same cell are NOT colliding (grid PT exemption)", async ({
-    appPage: page,
-  }) => {
+  test("PT connector and support at same cell are NOT colliding (grid PT exemption)", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       // Support along Y; PT-Z connector rotated 90deg around X so effective PT axis = Y
@@ -67,9 +67,7 @@ test.describe("Collision detection", () => {
     expect(result.hasC2).toBe(true);
   });
 
-  test("adjacent parts (no shared cells) do NOT collide (grid)", async ({
-    appPage: page,
-  }) => {
+  test("adjacent parts (no shared cells) do NOT collide (grid)", async ({ appPage: page }) => {
     // support-1u at [0,0,0] occupies cell [0,0,0]
     // support-1u at [0,1,0] occupies cell [0,1,0]
     // They are adjacent but not overlapping
@@ -83,9 +81,7 @@ test.describe("Collision detection", () => {
     expect(result).toBe(0);
   });
 
-  test("connector nudged 0.2 into a support shares grid cell (grid is conservative)", async ({
-    appPage: page,
-  }) => {
+  test("connector nudged 0.2 into a support shares grid cell (grid is conservative)", async ({ appPage: page }) => {
     // Grid-level detection is conservative: shared cell = flagged
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -99,9 +95,7 @@ test.describe("Collision detection", () => {
 
   // --- Fine mesh collision (async, BVH-based) ---
 
-  test("two connectors at the same position are detected as colliding (mesh)", async ({
-    appPage: page,
-  }) => {
+  test("two connectors at the same position are detected as colliding (mesh)", async ({ appPage: page }) => {
     // Place parts and wait for GLB geometries to register
     const ids = await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -128,16 +122,18 @@ test.describe("Collision detection", () => {
       const a = (window as any).__assembly;
       const { detectCollidingPartIdsMesh } = (window as any).__collision;
       const colliding = await detectCollidingPartIdsMesh(a);
-      return { has1: colliding.has(ids.id1), has2: colliding.has(ids.id2), size: colliding.size };
+      return {
+        has1: colliding.has(ids.id1),
+        has2: colliding.has(ids.id2),
+        size: colliding.size,
+      };
     }, ids);
 
     expect(result.has1).toBe(true);
     expect(result.has2).toBe(true);
   });
 
-  test("two connectors far apart do NOT collide (mesh)", async ({
-    appPage: page,
-  }) => {
+  test("two connectors far apart do NOT collide (mesh)", async ({ appPage: page }) => {
     await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.addPart("connector-2d2w", [0, 0, 0]);
@@ -166,9 +162,7 @@ test.describe("Collision detection", () => {
     expect(result).toBe(0);
   });
 
-  test("PT connector + support along matching axis do NOT collide (mesh)", async ({
-    appPage: page,
-  }) => {
+  test("PT connector + support along matching axis do NOT collide (mesh)", async ({ appPage: page }) => {
     await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.addPart("support-3u", [0, 0, 0], [0, 0, 0], "z");
@@ -197,9 +191,7 @@ test.describe("Collision detection", () => {
     expect(result).toBe(0);
   });
 
-  test("adjacent parts with small gap do NOT collide (mesh)", async ({
-    appPage: page,
-  }) => {
+  test("adjacent parts with small gap do NOT collide (mesh)", async ({ appPage: page }) => {
     // Place two supports side by side with 1 grid cell gap
     await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -229,9 +221,7 @@ test.describe("Collision detection", () => {
     expect(result).toBe(0);
   });
 
-  test("connector-3d5w adjacent to support-14u along z should NOT collide", async ({
-    appPage: page,
-  }) => {
+  test("connector-3d5w adjacent to support-14u along z should NOT collide", async ({ appPage: page }) => {
     // From user save: support-14u at [-1.6, 0, 3.7] oriented "z", connector-3d5w at [-1.6, 0, 2.7]
     const ids = await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -286,9 +276,7 @@ test.describe("Collision detection", () => {
     expect(meshResult.size).toBe(0);
   });
 
-  test("mesh collision can be cancelled via AbortSignal", async ({
-    appPage: page,
-  }) => {
+  test("mesh collision can be cancelled via AbortSignal", async ({ appPage: page }) => {
     await page.evaluate(() => {
       const a = (window as any).__assembly;
       // Place overlapping parts so there's real work to do
@@ -309,9 +297,7 @@ test.describe("Collision detection", () => {
     expect(result).toBe(0);
   });
 
-  test("PT connector offset from support SHOULD collide (misaligned PT)", async ({
-    appPage: page,
-  }) => {
+  test("PT connector offset from support SHOULD collide (misaligned PT)", async ({ appPage: page }) => {
     // PT-Z connector at [-1,0,4] and support-14u at [-1.6,0,3.7] oriented "z"
     // The connector is offset 0.6 grid units in x — support doesn't pass through the hole
     const ids = await page.evaluate(() => {

--- a/configurator/e2e/fit-camera.spec.ts
+++ b/configurator/e2e/fit-camera.spec.ts
@@ -1,9 +1,7 @@
 import { test, expect } from "./fixtures";
 
 test.describe("FitCamera on load", () => {
-  test("camera target moves to assembly center on reload with parts", async ({
-    appPage: page,
-  }) => {
+  test("camera target moves to assembly center on reload with parts", async ({ appPage: page }) => {
     // Place parts far from origin so the assembly center is clearly non-zero
     await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -16,10 +14,9 @@ test.describe("FitCamera on load", () => {
     // Reload — parts persist via localStorage, FitCamera runs on mount
     await page.reload();
     await page.waitForSelector(".app", { timeout: 10_000 });
-    await page.waitForFunction(
-      () => !!(window as any).__controls?.target && !!(window as any).__camera,
-      { timeout: 10_000 },
-    );
+    await page.waitForFunction(() => !!(window as any).__controls?.target && !!(window as any).__camera, {
+      timeout: 10_000,
+    });
 
     const result = await page.evaluate(() => {
       const controls = (window as any).__controls;
@@ -48,9 +45,7 @@ test.describe("FitCamera on load", () => {
     expect(result!.camY).toBeGreaterThan(0);
   });
 
-  test("camera target stays at origin when no parts are placed", async ({
-    appPage: page,
-  }) => {
+  test("camera target stays at origin when no parts are placed", async ({ appPage: page }) => {
     // Clear any existing parts and reload
     await page.evaluate(() => {
       (window as any).__assembly.clear();
@@ -58,10 +53,9 @@ test.describe("FitCamera on load", () => {
 
     await page.reload();
     await page.waitForSelector(".app", { timeout: 10_000 });
-    await page.waitForFunction(
-      () => !!(window as any).__controls?.target,
-      { timeout: 10_000 },
-    );
+    await page.waitForFunction(() => !!(window as any).__controls?.target, {
+      timeout: 10_000,
+    });
 
     const result = await page.evaluate(() => {
       const controls = (window as any).__controls;

--- a/configurator/e2e/fixtures.ts
+++ b/configurator/e2e/fixtures.ts
@@ -6,7 +6,9 @@ import { test as base, type Page } from "@playwright/test";
 export async function waitForApp(page: Page) {
   await page.waitForSelector(".app", { timeout: 10_000 });
   // Wait for R3F to mount and expose the scene object
-  await page.waitForFunction(() => !!(window as any).__scene, { timeout: 10_000 });
+  await page.waitForFunction(() => !!(window as any).__scene, {
+    timeout: 10_000,
+  });
 }
 
 /**
@@ -16,9 +18,7 @@ export async function clickCatalogItem(page: Page, name: string) {
   await page.evaluate((n) => {
     const items = document.querySelectorAll(".catalog-item");
     for (const item of items) {
-      if (
-        item.querySelector(".catalog-item-name")?.textContent?.trim() === n
-      ) {
+      if (item.querySelector(".catalog-item-name")?.textContent?.trim() === n) {
         (item as HTMLElement).click();
         return;
       }
@@ -26,8 +26,9 @@ export async function clickCatalogItem(page: Page, name: string) {
   }, name);
   // Wait for React to process the click
   await page.waitForFunction(
-    (n) => !!document.querySelector(".catalog-item.active .catalog-item-name")
-      || document.querySelector(".viewport")?.getAttribute("data-placing") != null,
+    (n) =>
+      !!document.querySelector(".catalog-item.active .catalog-item-name") ||
+      document.querySelector(".viewport")?.getAttribute("data-placing") != null,
     name,
     { timeout: 3_000 },
   );
@@ -57,11 +58,9 @@ export async function waitForMesh(page: Page, objectName: string, timeout = 10_0
  * Wait for the BOM table to have at least `minRows` rows.
  */
 export async function waitForBOM(page: Page, minRows = 1) {
-  await page.waitForFunction(
-    (min: number) => document.querySelectorAll(".bom-table tbody tr").length >= min,
-    minRows,
-    { timeout: 5_000 },
-  );
+  await page.waitForFunction((min: number) => document.querySelectorAll(".bom-table tbody tr").length >= min, minRows, {
+    timeout: 5_000,
+  });
 }
 
 /**
@@ -89,10 +88,7 @@ export async function getBBox(page: Page, objectName: string) {
         if (i === 0) {
           chain[i].matrixWorld.copy(chain[i].matrix);
         } else {
-          chain[i].matrixWorld.multiplyMatrices(
-            chain[i - 1].matrixWorld,
-            chain[i].matrix
-          );
+          chain[i].matrixWorld.multiplyMatrices(chain[i - 1].matrixWorld, chain[i].matrix);
         }
       }
     };

--- a/configurator/e2e/import-3mf.spec.ts
+++ b/configurator/e2e/import-3mf.spec.ts
@@ -62,7 +62,10 @@ function createMinimal3MF(): Uint8Array {
   const files: { name: string; data: Uint8Array }[] = [
     { name: "_rels/.rels", data: new TextEncoder().encode(relsXml) },
     { name: "3D/3dmodel.model", data: new TextEncoder().encode(modelXml) },
-    { name: "[Content_Types].xml", data: new TextEncoder().encode(contentTypesXml) },
+    {
+      name: "[Content_Types].xml",
+      data: new TextEncoder().encode(contentTypesXml),
+    },
   ];
 
   return buildZipStore(files);
@@ -162,9 +165,18 @@ function createMultiModel3MF(): Uint8Array {
   return buildZipStore([
     { name: "_rels/.rels", data: new TextEncoder().encode(relsXml) },
     { name: "3D/3dmodel.model", data: new TextEncoder().encode(rootModelXml) },
-    { name: "3D/Objects/part_a.model", data: new TextEncoder().encode(partAXml) },
-    { name: "3D/Objects/part_b.model", data: new TextEncoder().encode(partBXml) },
-    { name: "[Content_Types].xml", data: new TextEncoder().encode(contentTypesXml) },
+    {
+      name: "3D/Objects/part_a.model",
+      data: new TextEncoder().encode(partAXml),
+    },
+    {
+      name: "3D/Objects/part_b.model",
+      data: new TextEncoder().encode(partBXml),
+    },
+    {
+      name: "[Content_Types].xml",
+      data: new TextEncoder().encode(contentTypesXml),
+    },
   ]);
 }
 
@@ -180,17 +192,17 @@ function buildZipStore(files: { name: string; data: Uint8Array }[]): Uint8Array 
     // Local file header (30 bytes + name + data)
     const local = new ArrayBuffer(30 + nameBytes.length + data.length);
     const lv = new DataView(local);
-    lv.setUint32(0, 0x04034b50, true);   // signature
-    lv.setUint16(4, 20, true);            // version needed
-    lv.setUint16(6, 0, true);             // flags
-    lv.setUint16(8, 0, true);             // compression: STORE
-    lv.setUint16(10, 0, true);            // mod time
-    lv.setUint16(12, 0, true);            // mod date
-    lv.setUint32(14, crc32(data), true);  // CRC-32
-    lv.setUint32(18, data.length, true);  // compressed size
-    lv.setUint32(22, data.length, true);  // uncompressed size
+    lv.setUint32(0, 0x04034b50, true); // signature
+    lv.setUint16(4, 20, true); // version needed
+    lv.setUint16(6, 0, true); // flags
+    lv.setUint16(8, 0, true); // compression: STORE
+    lv.setUint16(10, 0, true); // mod time
+    lv.setUint16(12, 0, true); // mod date
+    lv.setUint32(14, crc32(data), true); // CRC-32
+    lv.setUint32(18, data.length, true); // compressed size
+    lv.setUint32(22, data.length, true); // uncompressed size
     lv.setUint16(26, nameBytes.length, true); // name length
-    lv.setUint16(28, 0, true);            // extra length
+    lv.setUint16(28, 0, true); // extra length
     new Uint8Array(local).set(nameBytes, 30);
     new Uint8Array(local).set(data, 30 + nameBytes.length);
     localEntries.push(new Uint8Array(local));
@@ -198,23 +210,23 @@ function buildZipStore(files: { name: string; data: Uint8Array }[]): Uint8Array 
     // Central directory header (46 bytes + name)
     const central = new ArrayBuffer(46 + nameBytes.length);
     const cv = new DataView(central);
-    cv.setUint32(0, 0x02014b50, true);   // signature
-    cv.setUint16(4, 20, true);            // version made by
-    cv.setUint16(6, 20, true);            // version needed
-    cv.setUint16(8, 0, true);             // flags
-    cv.setUint16(10, 0, true);            // compression: STORE
-    cv.setUint16(12, 0, true);            // mod time
-    cv.setUint16(14, 0, true);            // mod date
-    cv.setUint32(16, crc32(data), true);  // CRC-32
-    cv.setUint32(20, data.length, true);  // compressed size
-    cv.setUint32(24, data.length, true);  // uncompressed size
+    cv.setUint32(0, 0x02014b50, true); // signature
+    cv.setUint16(4, 20, true); // version made by
+    cv.setUint16(6, 20, true); // version needed
+    cv.setUint16(8, 0, true); // flags
+    cv.setUint16(10, 0, true); // compression: STORE
+    cv.setUint16(12, 0, true); // mod time
+    cv.setUint16(14, 0, true); // mod date
+    cv.setUint32(16, crc32(data), true); // CRC-32
+    cv.setUint32(20, data.length, true); // compressed size
+    cv.setUint32(24, data.length, true); // uncompressed size
     cv.setUint16(28, nameBytes.length, true); // name length
-    cv.setUint16(30, 0, true);            // extra length
-    cv.setUint16(32, 0, true);            // comment length
-    cv.setUint16(34, 0, true);            // disk number start
-    cv.setUint16(36, 0, true);            // internal file attributes
-    cv.setUint32(38, 0, true);            // external file attributes
-    cv.setUint32(42, offset, true);       // relative offset of local header
+    cv.setUint16(30, 0, true); // extra length
+    cv.setUint16(32, 0, true); // comment length
+    cv.setUint16(34, 0, true); // disk number start
+    cv.setUint16(36, 0, true); // internal file attributes
+    cv.setUint32(38, 0, true); // external file attributes
+    cv.setUint32(42, offset, true); // relative offset of local header
     new Uint8Array(central).set(nameBytes, 46);
     centralEntries.push(new Uint8Array(central));
 
@@ -228,20 +240,26 @@ function buildZipStore(files: { name: string; data: Uint8Array }[]): Uint8Array 
   // End of central directory (22 bytes)
   const eocd = new ArrayBuffer(22);
   const ev = new DataView(eocd);
-  ev.setUint32(0, 0x06054b50, true);   // signature
-  ev.setUint16(4, 0, true);             // disk number
-  ev.setUint16(6, 0, true);             // disk with central dir
-  ev.setUint16(8, files.length, true);  // entries on this disk
+  ev.setUint32(0, 0x06054b50, true); // signature
+  ev.setUint16(4, 0, true); // disk number
+  ev.setUint16(6, 0, true); // disk with central dir
+  ev.setUint16(8, files.length, true); // entries on this disk
   ev.setUint16(10, files.length, true); // total entries
   ev.setUint32(12, centralDirSize, true);
   ev.setUint32(16, centralDirOffset, true);
-  ev.setUint16(20, 0, true);            // comment length
+  ev.setUint16(20, 0, true); // comment length
 
   const totalSize = offset + centralDirSize + 22;
   const result = new Uint8Array(totalSize);
   let pos = 0;
-  for (const l of localEntries) { result.set(l, pos); pos += l.length; }
-  for (const c of centralEntries) { result.set(c, pos); pos += c.length; }
+  for (const l of localEntries) {
+    result.set(l, pos);
+    pos += l.length;
+  }
+  for (const c of centralEntries) {
+    result.set(c, pos);
+    pos += c.length;
+  }
   result.set(new Uint8Array(eocd), pos);
 
   return result;
@@ -249,14 +267,14 @@ function buildZipStore(files: { name: string; data: Uint8Array }[]): Uint8Array 
 
 /** Simple CRC-32 for ZIP entries. */
 function crc32(data: Uint8Array): number {
-  let crc = 0xFFFFFFFF;
+  let crc = 0xffffffff;
   for (let i = 0; i < data.length; i++) {
     crc ^= data[i];
     for (let j = 0; j < 8; j++) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xEDB88320 : 0);
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
     }
   }
-  return (crc ^ 0xFFFFFFFF) >>> 0;
+  return (crc ^ 0xffffffff) >>> 0;
 }
 
 test.describe("3MF import", () => {
@@ -278,10 +296,7 @@ test.describe("3MF import", () => {
     expect(result[0]).toContain("custom-3mf-");
 
     // Place the imported 3MF part
-    const placed = await page.evaluate(
-      (id: string) => (window as any).__assembly.addPart(id, [0, 0, 0]),
-      result[0],
-    );
+    const placed = await page.evaluate((id: string) => (window as any).__assembly.addPart(id, [0, 0, 0]), result[0]);
     expect(placed).not.toBeNull();
 
     // Verify it appears in the BOM
@@ -295,9 +310,7 @@ test.describe("3MF import", () => {
     expect(bom.some((r) => r.name.includes("test-cube"))).toBe(true);
   });
 
-  test("import a multi-model 3MF (production extension) as separate parts", async ({
-    appPage: page,
-  }) => {
+  test("import a multi-model 3MF (production extension) as separate parts", async ({ appPage: page }) => {
     // Simulates BambuStudio-style 3MF with meshes in separate .model files
     // referenced via p:path (3MF production extension).
     const zipBytes = createMultiModel3MF();
@@ -315,17 +328,12 @@ test.describe("3MF import", () => {
 
     // Both parts should be placeable
     for (const { id } of result) {
-      const placed = await page.evaluate(
-        (partId: string) => (window as any).__assembly.addPart(partId, [0, 0, 0]),
-        id,
-      );
+      const placed = await page.evaluate((partId: string) => (window as any).__assembly.addPart(partId, [0, 0, 0]), id);
       expect(placed).not.toBeNull();
     }
   });
 
-  test("real BambuStudio 3MF imports correct number of parts", async ({
-    appPage: page,
-  }, testInfo) => {
+  test("real BambuStudio 3MF imports correct number of parts", async ({ appPage: page }, testInfo) => {
     testInfo.setTimeout(120_000);
     const filePath = path.resolve(__dirname, "../raw-models/HomeRacker+-+Pi5+Case.3mf");
     if (!fs.existsSync(filePath)) {

--- a/configurator/e2e/layout-catalog.spec.ts
+++ b/configurator/e2e/layout-catalog.spec.ts
@@ -21,14 +21,11 @@ test.describe("Layout", () => {
 });
 
 test.describe("Catalog", () => {
-  test("has 36 items and none active initially", async ({
-    appPage: page,
-  }) => {
+  test("has 36 items and none active initially", async ({ appPage: page }) => {
     const catalogItems = await page.evaluate(() => {
       const items = document.querySelectorAll(".catalog-item");
       return Array.from(items).map((el) => ({
-        name:
-          el.querySelector(".catalog-item-name")?.textContent?.trim() ?? "",
+        name: el.querySelector(".catalog-item-name")?.textContent?.trim() ?? "",
         active: el.classList.contains("active"),
       }));
     });
@@ -40,10 +37,7 @@ test.describe("Catalog", () => {
   test("contains expected part names", async ({ appPage: page }) => {
     const catalogNames = await page.evaluate(() => {
       const items = document.querySelectorAll(".catalog-item");
-      return Array.from(items).map(
-        (el) =>
-          el.querySelector(".catalog-item-name")?.textContent?.trim() ?? ""
-      );
+      return Array.from(items).map((el) => el.querySelector(".catalog-item-name")?.textContent?.trim() ?? "");
     });
 
     const expectedParts = [
@@ -72,22 +66,15 @@ test.describe("Catalog", () => {
 });
 
 test.describe("Placement mode", () => {
-  test("clicking catalog item enters placement mode", async ({
-    appPage: page,
-  }) => {
+  test("clicking catalog item enters placement mode", async ({ appPage: page }) => {
     await clickCatalogItem(page, "3D 6-Way");
 
     const afterClick = await page.evaluate(() => {
       const items = document.querySelectorAll(".catalog-item");
-      const activeItem = Array.from(items).find((el) =>
-        el.classList.contains("active")
-      );
+      const activeItem = Array.from(items).find((el) => el.classList.contains("active"));
       const hint = document.querySelector(".viewport-hint");
       return {
-        activeName:
-          activeItem
-            ?.querySelector(".catalog-item-name")
-            ?.textContent?.trim() ?? null,
+        activeName: activeItem?.querySelector(".catalog-item-name")?.textContent?.trim() ?? null,
         hintVisible: !!hint,
         hintText: hint?.textContent?.trim() ?? null,
       };
@@ -101,16 +88,11 @@ test.describe("Placement mode", () => {
   test("Escape exits placement mode", async ({ appPage: page }) => {
     await clickCatalogItem(page, "3D 6-Way");
     await page.keyboard.press("Escape");
-    await page.waitForFunction(
-      () => !document.querySelector(".catalog-item.active"),
-      { timeout: 3_000 },
-    );
+    await page.waitForFunction(() => !document.querySelector(".catalog-item.active"), { timeout: 3_000 });
 
     const afterEscape = await page.evaluate(() => {
       const items = document.querySelectorAll(".catalog-item");
-      const activeItem = Array.from(items).find((el) =>
-        el.classList.contains("active")
-      );
+      const activeItem = Array.from(items).find((el) => el.classList.contains("active"));
       const hint = document.querySelector(".viewport-hint");
       return {
         anyActive: !!activeItem,
@@ -125,18 +107,14 @@ test.describe("Placement mode", () => {
   test("switching between catalog items", async ({ appPage: page }) => {
     await clickCatalogItem(page, "Support (5u)");
     const active1 = await page.evaluate(() => {
-      const active = document.querySelector(
-        ".catalog-item.active .catalog-item-name"
-      );
+      const active = document.querySelector(".catalog-item.active .catalog-item-name");
       return active?.textContent?.trim() ?? null;
     });
     expect(active1).toBe("Support (5u)");
 
     await clickCatalogItem(page, "Lock Pin");
     const active2 = await page.evaluate(() => {
-      const active = document.querySelector(
-        ".catalog-item.active .catalog-item-name"
-      );
+      const active = document.querySelector(".catalog-item.active .catalog-item-name");
       return active?.textContent?.trim() ?? null;
     });
     expect(active2).toBe("Lock Pin");
@@ -144,9 +122,7 @@ test.describe("Placement mode", () => {
 });
 
 test.describe("Ghost preview", () => {
-  test("data-placing attribute matches selected part", async ({
-    appPage: page,
-  }) => {
+  test("data-placing attribute matches selected part", async ({ appPage: page }) => {
     const partNameToId: Record<string, string> = {
       "1D 1-Way": "connector-1d1w",
       "1D 2-Way": "connector-1d2w",
@@ -171,22 +147,17 @@ test.describe("Ghost preview", () => {
     for (const [partName, expectedId] of Object.entries(partNameToId)) {
       await clickCatalogItem(page, partName);
       const placing = await page.evaluate(
-        () =>
-          document.querySelector(".viewport")?.getAttribute("data-placing") ??
-          null
+        () => document.querySelector(".viewport")?.getAttribute("data-placing") ?? null,
       );
       expect(placing, `Ghost for "${partName}"`).toBe(expectedId);
     }
 
     await page.keyboard.press("Escape");
-    await page.waitForFunction(
-      () => !document.querySelector(".viewport")?.getAttribute("data-placing"),
-      { timeout: 3_000 },
-    );
+    await page.waitForFunction(() => !document.querySelector(".viewport")?.getAttribute("data-placing"), {
+      timeout: 3_000,
+    });
     const noGhost = await page.evaluate(
-      () =>
-        document.querySelector(".viewport")?.getAttribute("data-placing") ??
-        null
+      () => document.querySelector(".viewport")?.getAttribute("data-placing") ?? null,
     );
     expect(noGhost).toBeNull();
   });

--- a/configurator/e2e/orientation-rotation.spec.ts
+++ b/configurator/e2e/orientation-rotation.spec.ts
@@ -5,63 +5,45 @@ test.describe("Orientation-aware grid occupancy", () => {
     await page.evaluate(() => (window as any).__assembly.clear());
   });
 
-  test("x-oriented support occupies cells along X axis", async ({
-    appPage: page,
-  }) => {
+  test("x-oriented support occupies cells along X axis", async ({ appPage: page }) => {
     const orientedId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "x")
+      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "x"),
     );
     expect(orientedId).not.toBeNull();
 
     // Cell [1,0,0] should be occupied
-    const occupied = await page.evaluate(() =>
-      (window as any).__assembly.isOccupied([1, 0, 0])
-    );
+    const occupied = await page.evaluate(() => (window as any).__assembly.isOccupied([1, 0, 0]));
     expect(occupied).toBe(true);
 
     // Cell [2,0,0] should also be occupied
-    const occupied2 = await page.evaluate(() =>
-      (window as any).__assembly.isOccupied([2, 0, 0])
-    );
+    const occupied2 = await page.evaluate(() => (window as any).__assembly.isOccupied([2, 0, 0]));
     expect(occupied2).toBe(true);
 
     // Cell [0,1,0] should be free
-    const free1 = await page.evaluate(() =>
-      (window as any).__assembly.isOccupied([0, 1, 0])
-    );
+    const free1 = await page.evaluate(() => (window as any).__assembly.isOccupied([0, 1, 0]));
     expect(free1).toBe(false);
 
     // Cell [0,0,1] should also be free
-    const free2 = await page.evaluate(() =>
-      (window as any).__assembly.isOccupied([0, 0, 1])
-    );
+    const free2 = await page.evaluate(() => (window as any).__assembly.isOccupied([0, 0, 1]));
     expect(free2).toBe(false);
   });
 
-  test("z-oriented support occupies cells along Z axis", async ({
-    appPage: page,
-  }) => {
+  test("z-oriented support occupies cells along Z axis", async ({ appPage: page }) => {
     const orientedZ = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "z")
+      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "z"),
     );
     expect(orientedZ).not.toBeNull();
 
-    const occupiedZ1 = await page.evaluate(() =>
-      (window as any).__assembly.isOccupied([0, 0, 1])
-    );
+    const occupiedZ1 = await page.evaluate(() => (window as any).__assembly.isOccupied([0, 0, 1]));
     expect(occupiedZ1).toBe(true);
 
-    const freeY1 = await page.evaluate(() =>
-      (window as any).__assembly.isOccupied([0, 1, 0])
-    );
+    const freeY1 = await page.evaluate(() => (window as any).__assembly.isOccupied([0, 1, 0]));
     expect(freeY1).toBe(false);
   });
 });
 
 test.describe("Placement always succeeds (no collision)", () => {
-  test("parts can overlap freely", async ({
-    appPage: page,
-  }) => {
+  test("parts can overlap freely", async ({ appPage: page }) => {
     const results = await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.clear();
@@ -86,9 +68,7 @@ test.describe("Placement always succeeds (no collision)", () => {
 });
 
 test.describe("Rotation-aware grid occupancy", () => {
-  test("90° X rotation moves cells from Y to Z axis", async ({
-    appPage: page,
-  }) => {
+  test("90° X rotation moves cells from Y to Z axis", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.clear();
@@ -118,14 +98,20 @@ test.describe("Rotation-aware grid occupancy", () => {
 });
 
 test.describe("Auto-lift: rotation pushes part above ground", () => {
-  test("computeGroundLift returns correct offset for rotated support", async ({
-    appPage: page,
-  }) => {
+  test("computeGroundLift returns correct offset for rotated support", async ({ appPage: page }) => {
     const results = await page.evaluate(() => {
       const lift = (window as any).__computeGroundLift;
 
       // Get support-3u definition (gridCells: [0,0,0],[0,1,0],[0,2,0])
-      const def = { gridCells: [[0,0,0],[0,1,0],[0,2,0]], connectionPoints: [], category: "support" };
+      const def = {
+        gridCells: [
+          [0, 0, 0],
+          [0, 1, 0],
+          [0, 2, 0],
+        ],
+        connectionPoints: [],
+        category: "support",
+      };
 
       return {
         // No rotation → minY = 0 → lift = 0
@@ -148,9 +134,7 @@ test.describe("Auto-lift: rotation pushes part above ground", () => {
     expect(results.rot90z).toBe(0);
   });
 
-  test("computeGroundLift accounts for connector arm directions", async ({
-    appPage: page,
-  }) => {
+  test("computeGroundLift accounts for connector arm directions", async ({ appPage: page }) => {
     const results = await page.evaluate(() => {
       const lift = (window as any).__computeGroundLift;
 
@@ -177,9 +161,7 @@ test.describe("Auto-lift: rotation pushes part above ground", () => {
     expect(results.rot90x).toBe(0);
   });
 
-  test("support with 180° X rotation can be placed at lifted Y", async ({
-    appPage: page,
-  }) => {
+  test("support with 180° X rotation can be placed at lifted Y", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.clear();
@@ -195,18 +177,14 @@ test.describe("Auto-lift: rotation pushes part above ground", () => {
 });
 
 test.describe("Orientation keyboard hint", () => {
-  test("support hint mentions orientation, connector mentions rotate", async ({
-    appPage: page,
-  }) => {
+  test("support hint mentions orientation, connector mentions rotate", async ({ appPage: page }) => {
     await clickCatalogItem(page, "Support (3u)");
-    const supportHint = await page.evaluate(
-      () => document.querySelector(".viewport-hint")?.textContent?.trim() ?? ""
-    );
+    const supportHint = await page.evaluate(() => document.querySelector(".viewport-hint")?.textContent?.trim() ?? "");
     expect(supportHint).toContain("orientation");
 
     await clickCatalogItem(page, "3D 6-Way");
     const connectorHint = await page.evaluate(
-      () => document.querySelector(".viewport-hint")?.textContent?.trim() ?? ""
+      () => document.querySelector(".viewport-hint")?.textContent?.trim() ?? "",
     );
     expect(connectorHint).toContain("rotate");
     expect(connectorHint).not.toContain("orientation");

--- a/configurator/e2e/part-color.spec.ts
+++ b/configurator/e2e/part-color.spec.ts
@@ -6,27 +6,17 @@ test.describe("Part color", () => {
   });
 
   test("setPartColor persists on the data model", async ({ appPage: page }) => {
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0])
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0]));
     expect(id).not.toBeNull();
 
-    await page.evaluate(
-      ([id]) => (window as any).__assembly.setPartColor(id, "#ff0000"),
-      [id]
-    );
+    await page.evaluate(([id]) => (window as any).__assembly.setPartColor(id, "#ff0000"), [id]);
 
-    const color = await page.evaluate(
-      ([id]) => (window as any).__assembly.getPartById(id)?.color,
-      [id]
-    );
+    const color = await page.evaluate(([id]) => (window as any).__assembly.getPartById(id)?.color, [id]);
     expect(color).toBe("#ff0000");
   });
 
   test("setPartColor undefined resets to default", async ({ appPage: page }) => {
-    const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0])
-    );
+    const id = await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0]));
 
     await page.evaluate(
       ([id]) => {
@@ -34,23 +24,16 @@ test.describe("Part color", () => {
         a.setPartColor(id, "#ff0000");
         a.setPartColor(id, undefined);
       },
-      [id]
+      [id],
     );
 
-    const color = await page.evaluate(
-      ([id]) => (window as any).__assembly.getPartById(id)?.color,
-      [id]
-    );
+    const color = await page.evaluate(([id]) => (window as any).__assembly.getPartById(id)?.color, [id]);
     expect(color).toBeUndefined();
   });
 
   test("color picker hidden when nothing selected", async ({ appPage: page }) => {
-    await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0])
-    );
-    const visible = await page.evaluate(
-      () => !!document.querySelector(".color-picker")
-    );
+    await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0]));
+    const visible = await page.evaluate(() => !!document.querySelector(".color-picker"));
     expect(visible).toBe(false);
   });
 
@@ -75,13 +58,10 @@ test.describe("Part color", () => {
 
   test("color preserved when added via addPart parameter", async ({ appPage: page }) => {
     const id = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], undefined, "#abcdef")
+      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], undefined, "#abcdef"),
     );
 
-    const color = await page.evaluate(
-      ([id]) => (window as any).__assembly.getPartById(id)?.color,
-      [id]
-    );
+    const color = await page.evaluate(([id]) => (window as any).__assembly.getPartById(id)?.color, [id]);
     expect(color).toBe("#abcdef");
   });
 
@@ -91,10 +71,7 @@ test.describe("Part color", () => {
       const id1 = a.addPart("support-3u", [0, 0, 0]);
       const id2 = a.addPart("support-3u", [1, 0, 0]);
       a.setPartsColor([id1, id2], "#ff8c00");
-      return [
-        a.getPartById(id1)?.color,
-        a.getPartById(id2)?.color,
-      ];
+      return [a.getPartById(id1)?.color, a.getPartById(id2)?.color];
     });
 
     expect(colors[0]).toBe("#ff8c00");

--- a/configurator/e2e/pull-through-collision.spec.ts
+++ b/configurator/e2e/pull-through-collision.spec.ts
@@ -1,9 +1,7 @@
 import { test, expect } from "./fixtures";
 
 test.describe("Pull-through connector collision", () => {
-  test("PT connector can be placed on a support along the matching axis", async ({
-    appPage: page,
-  }) => {
+  test("PT connector can be placed on a support along the matching axis", async ({ appPage: page }) => {
     // Place a support at [0,0,0] oriented along Z
     const supportId = await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -20,9 +18,7 @@ test.describe("Pull-through connector collision", () => {
     expect(ptId).toBeTruthy();
   });
 
-  test("support can be placed through an existing PT connector", async ({
-    appPage: page,
-  }) => {
+  test("support can be placed through an existing PT connector", async ({ appPage: page }) => {
     // Place a PT-Z connector at [0,0,0]
     const ptId = await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -39,9 +35,7 @@ test.describe("Pull-through connector collision", () => {
     expect(supportId).toBeTruthy();
   });
 
-  test("PT connector allows support on any axis (not just matching PT axis)", async ({
-    appPage: page,
-  }) => {
+  test("PT connector allows support on any axis (not just matching PT axis)", async ({ appPage: page }) => {
     // Place a support at [0,0,0] oriented along X
     await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -57,9 +51,7 @@ test.describe("Pull-through connector collision", () => {
     expect(ptId).toBeTruthy();
   });
 
-  test("regular connector can also overlap supports (no collision)", async ({
-    appPage: page,
-  }) => {
+  test("regular connector can also overlap supports (no collision)", async ({ appPage: page }) => {
     // Place a support at [0,0,0] oriented along Z
     await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -75,9 +67,7 @@ test.describe("Pull-through connector collision", () => {
     expect(connId).toBeTruthy();
   });
 
-  test("PT connector respects rotation when checking axis match", async ({
-    appPage: page,
-  }) => {
+  test("PT connector respects rotation when checking axis match", async ({ appPage: page }) => {
     // Place a support along X
     await page.evaluate(() => {
       const a = (window as any).__assembly;
@@ -93,9 +83,7 @@ test.describe("Pull-through connector collision", () => {
     expect(ptId).toBeTruthy();
   });
 
-  test("PT connector with rotation still allows any support through", async ({
-    appPage: page,
-  }) => {
+  test("PT connector with rotation still allows any support through", async ({ appPage: page }) => {
     // Place a support along Y
     await page.evaluate(() => {
       const a = (window as any).__assembly;

--- a/configurator/e2e/snap-move.spec.ts
+++ b/configurator/e2e/snap-move.spec.ts
@@ -20,12 +20,8 @@ test.describe("Snap point discovery", () => {
         count: points.length,
         orientations: [...new Set(orientations)],
         directions: [...new Set(directions)],
-        hasZSnap: points.some(
-          (p: any) => p.orientation === "z" && p.socketDirection === "+z"
-        ),
-        hasXSnap: points.some(
-          (p: any) => p.orientation === "x" && p.socketDirection === "+x"
-        ),
+        hasZSnap: points.some((p: any) => p.orientation === "z" && p.socketDirection === "+z"),
+        hasXSnap: points.some((p: any) => p.orientation === "x" && p.socketDirection === "+x"),
       };
     });
 
@@ -35,9 +31,7 @@ test.describe("Snap point discovery", () => {
     expect(result.orientations.length).toBeGreaterThanOrEqual(2);
   });
 
-  test("findBestSnap returns nearest candidate", async ({
-    appPage: page,
-  }) => {
+  test("findBestSnap returns nearest candidate", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const snap = (window as any).__snap;
@@ -114,9 +108,7 @@ test.describe("2D2W L-shape connector snap", () => {
     expect(result.xOrient).toBe("x");
   });
 
-  test("placing support at +x snap occupies correct cells", async ({
-    appPage: page,
-  }) => {
+  test("placing support at +x snap occupies correct cells", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const snap = (window as any).__snap;
@@ -127,12 +119,7 @@ test.describe("2D2W L-shape connector snap", () => {
       const xSnap = points.find((p: any) => p.socketDirection === "+x");
       if (!xSnap) return { placed: false, reason: "no +x snap found" };
 
-      const id = a.addPart(
-        "support-5u",
-        xSnap.position,
-        [0, 0, 0],
-        xSnap.orientation
-      );
+      const id = a.addPart("support-5u", xSnap.position, [0, 0, 0], xSnap.orientation);
       if (!id) return { placed: false, reason: "addPart returned null" };
 
       const expectedCells: [number, number, number][] = [
@@ -153,9 +140,7 @@ test.describe("2D2W L-shape connector snap", () => {
     expect(result.connectorCellStillOccupied).toBe(true);
   });
 
-  test("no snap candidates after both slots filled", async ({
-    appPage: page,
-  }) => {
+  test("no snap candidates after both slots filled", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const snap = (window as any).__snap;
@@ -196,12 +181,7 @@ test.describe("Connector snap to vertical support top", () => {
       a.clear();
       a.addPart("support-5u", [5, 0, 5], [0, 0, 0], "y");
 
-      const points = snap.findConnectorSnapPoints(
-        a,
-        "connector-3d6w",
-        [5, 0, 5],
-        3
-      );
+      const points = snap.findConnectorSnapPoints(a, "connector-3d6w", [5, 0, 5], 3);
       const topSnap = points.find((p: any) => p.socketDirection === "+y");
       const bottomSnap = points.find((p: any) => p.socketDirection === "-y");
 
@@ -218,21 +198,14 @@ test.describe("Connector snap to vertical support top", () => {
     expect(result.hasBottomSnap).toBe(false);
   });
 
-  test("connector snaps to top of 10u support", async ({
-    appPage: page,
-  }) => {
+  test("connector snaps to top of 10u support", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const snap = (window as any).__snap;
       a.clear();
       a.addPart("support-10u", [5, 0, 5], [0, 0, 0], "y");
 
-      const points = snap.findConnectorSnapPoints(
-        a,
-        "connector-2d2w",
-        [5, 0, 5],
-        3
-      );
+      const points = snap.findConnectorSnapPoints(a, "connector-2d2w", [5, 0, 5], 3);
       const topSnap = points.find((p: any) => p.socketDirection === "+y");
 
       return {
@@ -256,39 +229,18 @@ test.describe("Ray-based snap proximity", () => {
       a.addPart("support-10u", [5, 0, 5], [0, 0, 0], "y");
 
       // Without ray — cursor too far on XZ plane
-      const withoutRay = snap.findConnectorSnapPoints(
-        a,
-        "connector-3d6w",
-        [5, 0, 10],
-        3
-      );
-      const topWithoutRay = withoutRay.find(
-        (p: any) => p.socketDirection === "+y"
-      );
+      const withoutRay = snap.findConnectorSnapPoints(a, "connector-3d6w", [5, 0, 10], 3);
+      const topWithoutRay = withoutRay.find((p: any) => p.socketDirection === "+y");
 
       // With ray pointing toward support top
       const rayOrigin = [5, 20, 15] as [number, number, number];
       const rawDir = [0, -10, -10] as [number, number, number];
-      const len = Math.sqrt(
-        rawDir[0] ** 2 + rawDir[1] ** 2 + rawDir[2] ** 2
-      );
-      const rayDir = [
-        rawDir[0] / len,
-        rawDir[1] / len,
-        rawDir[2] / len,
-      ] as [number, number, number];
+      const len = Math.sqrt(rawDir[0] ** 2 + rawDir[1] ** 2 + rawDir[2] ** 2);
+      const rayDir = [rawDir[0] / len, rawDir[1] / len, rawDir[2] / len] as [number, number, number];
       const ray = { origin: rayOrigin, direction: rayDir };
 
-      const withRay = snap.findConnectorSnapPoints(
-        a,
-        "connector-3d6w",
-        [5, 0, 10],
-        3,
-        ray
-      );
-      const topWithRay = withRay.find(
-        (p: any) => p.socketDirection === "+y"
-      );
+      const withRay = snap.findConnectorSnapPoints(a, "connector-3d6w", [5, 0, 10], 3, ray);
+      const topWithRay = withRay.find((p: any) => p.socketDirection === "+y");
 
       return {
         hasTopWithoutRay: !!topWithoutRay,
@@ -304,9 +256,7 @@ test.describe("Ray-based snap proximity", () => {
 });
 
 test.describe("Move part (programmatic)", () => {
-  test("move frees old position and occupies new", async ({
-    appPage: page,
-  }) => {
+  test("move frees old position and occupies new", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       a.clear();
@@ -318,12 +268,7 @@ test.describe("Move part (programmatic)", () => {
       if (!part) return { success: false, reason: "part not found" };
 
       a.removePart(id);
-      const newId = a.addPart(
-        part.definitionId,
-        [3, 1, 3],
-        part.rotation,
-        part.orientation
-      );
+      const newId = a.addPart(part.definitionId, [3, 1, 3], part.rotation, part.orientation);
 
       return {
         success: newId !== null,
@@ -339,9 +284,7 @@ test.describe("Move part (programmatic)", () => {
 });
 
 test.describe("No page errors", () => {
-  test("no unexpected page errors during test run", async ({
-    appPage: page,
-  }) => {
+  test("no unexpected page errors during test run", async ({ appPage: page }) => {
     // Page errors are collected by the appPage fixture
     // This test just validates the page loaded without issues
     const hasApp = await page.evaluate(() => !!document.querySelector(".app"));

--- a/configurator/e2e/snapfix.spec.ts
+++ b/configurator/e2e/snapfix.spec.ts
@@ -27,9 +27,7 @@ test.describe("Snapfix: support placement through PT connector", () => {
     }, fixtureWithoutLast);
   });
 
-  test("findBestSnap near PT connector returns valid placeable candidate", async ({
-    appPage: page,
-  }) => {
+  test("findBestSnap near PT connector returns valid placeable candidate", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const snap = (window as any).__snap;
@@ -60,9 +58,7 @@ test.describe("Snapfix: support placement through PT connector", () => {
     expect(result.placed).toBe(true);
   });
 
-  test("snapped support with user rotation around snapped axis is placeable", async ({
-    appPage: page,
-  }) => {
+  test("snapped support with user rotation around snapped axis is placeable", async ({ appPage: page }) => {
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;
       const snap = (window as any).__snap;
@@ -88,9 +84,7 @@ test.describe("Snapfix: support placement through PT connector", () => {
     expect(result.placed).toBe(true);
   });
 
-  test("all snap candidates near PT connector are placeable", async ({
-    appPage: page,
-  }) => {
+  test("all snap candidates near PT connector are placeable", async ({ appPage: page }) => {
     // Get ALL snap candidates (not just best), verify each is actually placeable
     const result = await page.evaluate(() => {
       const a = (window as any).__assembly;

--- a/configurator/e2e/sparse-collision.spec.ts
+++ b/configurator/e2e/sparse-collision.spec.ts
@@ -18,10 +18,18 @@ function createSparseSTL(): ArrayBuffer {
 
   // Helper to write a triangle (normal + 3 vertices + attribute)
   function writeTri(
-    nx: number, ny: number, nz: number,
-    x0: number, y0: number, z0: number,
-    x1: number, y1: number, z1: number,
-    x2: number, y2: number, z2: number,
+    nx: number,
+    ny: number,
+    nz: number,
+    x0: number,
+    y0: number,
+    z0: number,
+    x1: number,
+    y1: number,
+    z1: number,
+    x2: number,
+    y2: number,
+    z2: number,
   ) {
     for (const v of [nx, ny, nz, x0, y0, z0, x1, y1, z1, x2, y2, z2]) {
       view.setFloat32(offset, v, true);
@@ -44,19 +52,17 @@ test.describe("Sparse collision: perpendicular supports can cross", () => {
     await page.evaluate(() => (window as any).__assembly.clear());
   });
 
-  test("vertical and horizontal supports can share a cell", async ({
-    appPage: page,
-  }) => {
+  test("vertical and horizontal supports can share a cell", async ({ appPage: page }) => {
     // Place a vertical support (y-oriented) spanning cells [0,0,0] to [0,4,0]
     const verticalId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-5u", [0, 0, 0], [0, 0, 0], "y")
+      (window as any).__assembly.addPart("support-5u", [0, 0, 0], [0, 0, 0], "y"),
     );
     expect(verticalId).not.toBeNull();
 
     // Place a horizontal support (x-oriented) at [0,2,0] spanning [-2..2, 2, 0]
     // This crosses the vertical support at cell [0,2,0]
     const horizontalId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-5u", [-2, 2, 0], [0, 0, 0], "x")
+      (window as any).__assembly.addPart("support-5u", [-2, 2, 0], [0, 0, 0], "x"),
     );
 
     // Currently fails because cell [0,2,0] is occupied by the vertical support.
@@ -65,63 +71,43 @@ test.describe("Sparse collision: perpendicular supports can cross", () => {
     expect(horizontalId).not.toBeNull();
   });
 
-  test("three perpendicular supports can all share one cell", async ({
-    appPage: page,
-  }) => {
+  test("three perpendicular supports can all share one cell", async ({ appPage: page }) => {
     // Place Y-axis support spanning [0,0,0] to [0,2,0]
-    const yId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "y")
-    );
+    const yId = await page.evaluate(() => (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "y"));
     expect(yId).not.toBeNull();
 
     // Place X-axis support crossing at [0,1,0]
-    const xId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [-1, 1, 0], [0, 0, 0], "x")
-    );
+    const xId = await page.evaluate(() => (window as any).__assembly.addPart("support-3u", [-1, 1, 0], [0, 0, 0], "x"));
     expect(xId).not.toBeNull();
 
     // Place Z-axis support also crossing at [0,1,0]
-    const zId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 1, -1], [0, 0, 0], "z")
-    );
+    const zId = await page.evaluate(() => (window as any).__assembly.addPart("support-3u", [0, 1, -1], [0, 0, 0], "z"));
     expect(zId).not.toBeNull();
   });
 
-  test("same-axis supports can overlap (no collision)", async ({
-    appPage: page,
-  }) => {
+  test("same-axis supports can overlap (no collision)", async ({ appPage: page }) => {
     // Place a vertical support at [0,0,0]
-    const id1 = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-5u", [0, 0, 0], [0, 0, 0], "y")
-    );
+    const id1 = await page.evaluate(() => (window as any).__assembly.addPart("support-5u", [0, 0, 0], [0, 0, 0], "y"));
     expect(id1).not.toBeNull();
 
     // Place another vertical support overlapping at [0,0,0] — succeeds (no collision system)
-    const id2 = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "y")
-    );
+    const id2 = await page.evaluate(() => (window as any).__assembly.addPart("support-3u", [0, 0, 0], [0, 0, 0], "y"));
     expect(id2).not.toBeNull();
   });
 
-  test("connector and support can overlap (no collision)", async ({
-    appPage: page,
-  }) => {
+  test("connector and support can overlap (no collision)", async ({ appPage: page }) => {
     // Connector at [0,1,0]
-    const connId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0])
-    );
+    const connId = await page.evaluate(() => (window as any).__assembly.addPart("connector-3d6w", [0, 1, 0]));
     expect(connId).not.toBeNull();
 
     // Support crossing through the connector cell — succeeds (no collision system)
     const supportId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-3u", [-1, 1, 0], [0, 0, 0], "x")
+      (window as any).__assembly.addPart("support-3u", [-1, 1, 0], [0, 0, 0], "x"),
     );
     expect(supportId).not.toBeNull();
   });
 
-  test("custom part with hollow interior allows placement inside", async ({
-    appPage: page,
-  }) => {
+  test("custom part with hollow interior allows placement inside", async ({ appPage: page }) => {
     // Import a sparse STL: geometry in cells [0,0,0] and [2,0,0],
     // but cell [1,0,0] is empty (hollow interior).
     // Bounding box spans 3 cells, but only 2 have actual triangles.
@@ -138,16 +124,13 @@ test.describe("Sparse collision: perpendicular supports can cross", () => {
     expect(customId).toBeTruthy();
 
     // Place the custom part at [0,0,0]
-    const placed = await page.evaluate((id: string) =>
-      (window as any).__assembly.addPart(id, [0, 0, 0]),
-      customId
-    );
+    const placed = await page.evaluate((id: string) => (window as any).__assembly.addPart(id, [0, 0, 0]), customId);
     expect(placed).not.toBeNull();
 
     // The hollow interior (cell [1,0,0]) should NOT be occupied.
     // A support along Y-axis at [1,0,0] should be placeable.
     const supportId = await page.evaluate(() =>
-      (window as any).__assembly.addPart("support-1u", [1, 0, 0], [0, 0, 0], "y")
+      (window as any).__assembly.addPart("support-1u", [1, 0, 0], [0, 0, 0], "y"),
     );
 
     // This FAILS with the current code because importSTL fills the entire

--- a/configurator/package.json
+++ b/configurator/package.json
@@ -1,30 +1,33 @@
 {
-  "name": "homeracker-configurator",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "bun run scripts/dev-server.ts",
-    "build": "bun run scripts/build.ts",
-    "generate-models": "bash scripts/generate-models.sh",
-    "test:e2e": "npx playwright test",
-    "test:e2e:headed": "npx playwright test --headed",
-    "test:e2e:ui": "npx playwright test --ui",
-    "screenshot": "bun run scripts/screenshot.ts"
-  },
-  "dependencies": {
-    "@react-three/drei": "^10.0.0",
-    "@react-three/fiber": "^9.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "three": "^0.172.0",
-    "three-mesh-bvh": "^0.9.9"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.58.2",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "@types/three": "^0.172.0",
-    "typescript": "^5.7.0"
-  }
+	"name": "homeracker-configurator",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "bun run scripts/dev-server.ts",
+		"build": "bun run scripts/build.ts",
+		"generate-models": "bash scripts/generate-models.sh",
+		"test:e2e": "npx playwright test",
+		"test:e2e:headed": "npx playwright test --headed",
+		"test:e2e:ui": "npx playwright test --ui",
+		"screenshot": "bun run scripts/screenshot.ts",
+		"format": "biome format --write .",
+		"format:check": "biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false ."
+	},
+	"dependencies": {
+		"@react-three/drei": "^10.0.0",
+		"@react-three/fiber": "^9.0.0",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"three": "^0.172.0",
+		"three-mesh-bvh": "^0.9.9"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.10",
+		"@playwright/test": "^1.58.2",
+		"@types/react": "^19.0.0",
+		"@types/react-dom": "^19.0.0",
+		"@types/three": "^0.172.0",
+		"typescript": "^5.7.0"
+	}
 }

--- a/configurator/package.json
+++ b/configurator/package.json
@@ -10,7 +10,9 @@
     "test:e2e": "npx playwright test",
     "test:e2e:headed": "npx playwright test --headed",
     "test:e2e:ui": "npx playwright test --ui",
-    "screenshot": "bun run scripts/screenshot.ts"
+    "screenshot": "bun run scripts/screenshot.ts",
+		"format": "biome format --write .",
+		"format:check": "biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false ."
   },
   "dependencies": {
     "@react-three/drei": "^10.0.0",

--- a/configurator/playwright.config.ts
+++ b/configurator/playwright.config.ts
@@ -1,33 +1,33 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  testDir: "./e2e",
-  timeout: 30_000,
-  retries: 0,
-  use: {
-    baseURL: "http://localhost:3001",
-    viewport: { width: 1280, height: 800 },
-    // Use software rendering for headless WebGL
-    launchOptions: {
-      args: [
-        "--no-sandbox",
-        "--disable-setuid-sandbox",
-        "--enable-webgl",
-        "--use-gl=angle",
-        "--use-angle=swiftshader",
-      ],
-    },
-  },
-  projects: [
-    {
-      name: "chromium",
-      use: { browserName: "chromium" },
-    },
-  ],
-  webServer: {
-    command: "bun run scripts/dev-server.ts",
-    port: 3001,
-    reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
-  },
+	testDir: "./e2e",
+	timeout: 30_000,
+	retries: 0,
+	use: {
+		baseURL: "http://localhost:3001",
+		viewport: { width: 1280, height: 800 },
+		// Use software rendering for headless WebGL
+		launchOptions: {
+			args: [
+				"--no-sandbox",
+				"--disable-setuid-sandbox",
+				"--enable-webgl",
+				"--use-gl=angle",
+				"--use-angle=swiftshader",
+			],
+		},
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: { browserName: "chromium" },
+		},
+	],
+	webServer: {
+		command: "bun run scripts/dev-server.ts",
+		port: 3001,
+		reuseExistingServer: !process.env.CI,
+		timeout: 15_000,
+	},
 });

--- a/configurator/scripts/build.ts
+++ b/configurator/scripts/build.ts
@@ -44,12 +44,9 @@ const indexContent = readFileSync(join(PROJECT_ROOT, "index.html"), "utf-8");
 const rewritten = indexContent
   .replace(
     '<script type="module" src="/src/main.tsx"></script>',
-    `<script type="module" src="./${jsFilename}"></script>`
+    `<script type="module" src="./${jsFilename}"></script>`,
   )
-  .replace(
-    'href="/src/styles/main.css"',
-    'href="./styles/main.css"'
-  );
+  .replace('href="/src/styles/main.css"', 'href="./styles/main.css"');
 writeFileSync(join(DIST_DIR, "index.html"), rewritten);
 
 // Copy public/ assets to dist/

--- a/configurator/scripts/debug-scene.ts
+++ b/configurator/scripts/debug-scene.ts
@@ -7,7 +7,9 @@ const PUBLIC_DIR = join(PROJECT_ROOT, "public");
 
 await Bun.build({
   entrypoints: [join(PROJECT_ROOT, "src", "main.tsx")],
-  outdir: DIST_DIR, naming: "[name].[ext]", sourcemap: "linked",
+  outdir: DIST_DIR,
+  naming: "[name].[ext]",
+  sourcemap: "linked",
   define: { "process.env.NODE_ENV": JSON.stringify("development") },
 });
 
@@ -19,7 +21,10 @@ const server = Bun.serve({
     if (pathname.startsWith("/src/")) {
       const mapped = pathname.replace("/src/", "").replace(".tsx", ".js").replace(".ts", ".js");
       const file = Bun.file(join(DIST_DIR, mapped));
-      if (await file.exists()) return new Response(file, { headers: { "Content-Type": "application/javascript" } });
+      if (await file.exists())
+        return new Response(file, {
+          headers: { "Content-Type": "application/javascript" },
+        });
     }
     if (pathname !== "/" && pathname !== "/index.html") {
       for (const dir of [PUBLIC_DIR, PROJECT_ROOT, DIST_DIR]) {
@@ -28,7 +33,9 @@ const server = Bun.serve({
       }
     }
     const html = await Bun.file(join(PROJECT_ROOT, "index.html")).text();
-    return new Response(html.replace('src="/src/main.tsx"', 'src="/src/main.js"'), { headers: { "Content-Type": "text/html" } });
+    return new Response(html.replace('src="/src/main.tsx"', 'src="/src/main.js"'), {
+      headers: { "Content-Type": "text/html" },
+    });
   },
 });
 
@@ -38,11 +45,14 @@ const browser = await puppeteer.launch({
 });
 const page = await browser.newPage();
 await page.setViewport({ width: 1280, height: 800 });
-await page.goto("http://localhost:" + server.port, { waitUntil: "networkidle0", timeout: 15000 });
-await new Promise(r => setTimeout(r, 2000));
+await page.goto("http://localhost:" + server.port, {
+  waitUntil: "networkidle0",
+  timeout: 15000,
+});
+await new Promise((r) => setTimeout(r, 2000));
 
 await page.evaluate(() => (window as any).__assembly.addPart("support-3u", [0, 0, 0]));
-await new Promise(r => setTimeout(r, 2000));
+await new Promise((r) => setTimeout(r, 2000));
 
 const debug = await page.evaluate(() => {
   const scene = (window as any).__scene;

--- a/configurator/scripts/dev-server.ts
+++ b/configurator/scripts/dev-server.ts
@@ -89,7 +89,7 @@ const server = Bun.serve({
     // Rewrite the script src to point to the built JS
     const rewritten = indexContent.replace(
       '<script type="module" src="/src/main.tsx"></script>',
-      '<script type="module" src="/src/main.js"></script>'
+      '<script type="module" src="/src/main.js"></script>',
     );
     return new Response(rewritten, {
       headers: { "Content-Type": "text/html" },

--- a/configurator/scripts/e2e-test.ts
+++ b/configurator/scripts/e2e-test.ts
@@ -46,7 +46,10 @@ const server = Bun.serve({
     if (pathname.startsWith("/src/") && /\.(tsx?|jsx?)$/.test(pathname)) {
       const mapped = pathname.replace("/src/", "").replace(".tsx", ".js").replace(".ts", ".js");
       const file = Bun.file(join(DIST_DIR, mapped));
-      if (await file.exists()) return new Response(file, { headers: { "Content-Type": "application/javascript" } });
+      if (await file.exists())
+        return new Response(file, {
+          headers: { "Content-Type": "application/javascript" },
+        });
     }
 
     if (pathname !== "/" && pathname !== "/index.html") {
@@ -57,10 +60,9 @@ const server = Bun.serve({
     }
 
     const html = await Bun.file(join(PROJECT_ROOT, "index.html")).text();
-    return new Response(
-      html.replace('src="/src/main.tsx"', 'src="/src/main.js"'),
-      { headers: { "Content-Type": "text/html" } }
-    );
+    return new Response(html.replace('src="/src/main.tsx"', 'src="/src/main.js"'), {
+      headers: { "Content-Type": "text/html" },
+    });
   },
 });
 
@@ -132,17 +134,35 @@ const catalogItems = await page.evaluate(() => {
 
 // 18 supports + 9 connectors + 7 foot connectors + 2 lock pins = 36
 assert("Catalog has 36 items", catalogItems.length === 36, `got ${catalogItems.length}`);
-assert("No item is active initially", catalogItems.every((i) => !i.active));
+assert(
+  "No item is active initially",
+  catalogItems.every((i) => !i.active),
+);
 
 const expectedParts = [
-  "Support (1u)", "Support (5u)", "Support (10u)", "Support (18u)",
-  "1D 1-Way", "1D 2-Way", "2D 2-Way", "2D 3-Way", "2D 4-Way",
-  "3D 3-Way", "3D 4-Way", "3D 5-Way", "3D 6-Way",
-  "2D 2-Way Foot", "3D 4-Way Foot",
-  "Lock Pin", "Lock Pin (No Grip)",
+  "Support (1u)",
+  "Support (5u)",
+  "Support (10u)",
+  "Support (18u)",
+  "1D 1-Way",
+  "1D 2-Way",
+  "2D 2-Way",
+  "2D 3-Way",
+  "2D 4-Way",
+  "3D 3-Way",
+  "3D 4-Way",
+  "3D 5-Way",
+  "3D 6-Way",
+  "2D 2-Way Foot",
+  "3D 4-Way Foot",
+  "Lock Pin",
+  "Lock Pin (No Grip)",
 ];
 for (const name of expectedParts) {
-  assert(`Catalog contains "${name}"`, catalogItems.some((i) => i.name === name));
+  assert(
+    `Catalog contains "${name}"`,
+    catalogItems.some((i) => i.name === name),
+  );
 }
 
 // ──────────────────────────────────────────────
@@ -151,7 +171,7 @@ for (const name of expectedParts) {
 console.log("\n--- Test: Placement mode ---");
 
 // Click the "3D 6-Way" connector (4th catalog item)
-const connector6WayBtn = await page.$('.catalog-item:nth-child(4)');
+const connector6WayBtn = await page.$(".catalog-item:nth-child(4)");
 if (connector6WayBtn) {
   // First, find the correct button by text
   await page.evaluate(() => {
@@ -176,9 +196,17 @@ if (connector6WayBtn) {
     };
   });
 
-  assert("3D 6-Way becomes active after click", afterClick.activeName === "3D 6-Way", `active: ${afterClick.activeName}`);
+  assert(
+    "3D 6-Way becomes active after click",
+    afterClick.activeName === "3D 6-Way",
+    `active: ${afterClick.activeName}`,
+  );
   assert("Viewport hint appears in placement mode", afterClick.hintVisible);
-  assert("Hint says click to place", afterClick.hintText?.includes("Click to place") ?? false, afterClick.hintText ?? "no hint");
+  assert(
+    "Hint says click to place",
+    afterClick.hintText?.includes("Click to place") ?? false,
+    afterClick.hintText ?? "no hint",
+  );
 }
 
 // Press Escape to exit placement mode
@@ -311,7 +339,11 @@ const bom2 = await page.evaluate(() => {
   }));
 });
 
-assert("BOM quantity updates to 2", bom2.some((r) => r.qty === "2"), `rows: ${JSON.stringify(bom2)}`);
+assert(
+  "BOM quantity updates to 2",
+  bom2.some((r) => r.qty === "2"),
+  `rows: ${JSON.stringify(bom2)}`,
+);
 
 // Place a support between them
 const placed3 = await page.evaluate(() => {
@@ -329,7 +361,11 @@ const bom3 = await page.evaluate(() => {
 });
 
 assert("BOM shows at least 2 rows (connector + support)", bom3.length >= 2, `got ${bom3.length}`);
-assert("BOM includes support", bom3.some((r) => r.name.includes("Support")), `rows: ${JSON.stringify(bom3)}`);
+assert(
+  "BOM includes support",
+  bom3.some((r) => r.name.includes("Support")),
+  `rows: ${JSON.stringify(bom3)}`,
+);
 
 // ──────────────────────────────────────────────
 // Test 5: Collision detection
@@ -472,7 +508,10 @@ const getBBox = async (objectName: string) => {
       // Walk up parent chain, force updateMatrix on each
       const chain: any[] = [];
       let p = obj;
-      while (p) { chain.unshift(p); p = p.parent; }
+      while (p) {
+        chain.unshift(p);
+        p = p.parent;
+      }
       for (const node of chain) {
         node.updateMatrix();
       }
@@ -487,7 +526,10 @@ const getBBox = async (objectName: string) => {
     };
 
     // Compute world bounding box by traversing meshes
-    const box = { min: [Infinity, Infinity, Infinity], max: [-Infinity, -Infinity, -Infinity] };
+    const box = {
+      min: [Infinity, Infinity, Infinity],
+      max: [-Infinity, -Infinity, -Infinity],
+    };
     target.traverse((child: any) => {
       if (child.isMesh && child.geometry) {
         forceUpdateMatrices(child);
@@ -508,9 +550,9 @@ const getBBox = async (objectName: string) => {
           const v = { x: c[0], y: c[1], z: c[2] };
           // Apply world matrix manually
           const e = child.matrixWorld.elements;
-          const wx = e[0]*v.x + e[4]*v.y + e[8]*v.z + e[12];
-          const wy = e[1]*v.x + e[5]*v.y + e[9]*v.z + e[13];
-          const wz = e[2]*v.x + e[6]*v.y + e[10]*v.z + e[14];
+          const wx = e[0] * v.x + e[4] * v.y + e[8] * v.z + e[12];
+          const wy = e[1] * v.x + e[5] * v.y + e[9] * v.z + e[13];
+          const wz = e[2] * v.x + e[6] * v.y + e[10] * v.z + e[14];
           box.min[0] = Math.min(box.min[0], wx);
           box.min[1] = Math.min(box.min[1], wy);
           box.min[2] = Math.min(box.min[2], wz);
@@ -553,7 +595,7 @@ if (ghostBBox) {
   assert(
     "Ghost preview is taller in Y than X (vertical orientation)",
     ghostBBox.sizeY > ghostBBox.sizeX * 2,
-    `Y=${ghostBBox.sizeY} X=${ghostBBox.sizeX}`
+    `Y=${ghostBBox.sizeY} X=${ghostBBox.sizeX}`,
   );
 }
 
@@ -578,25 +620,33 @@ if (placedBBox) {
   assert(
     "Placed part is taller in Y than X (vertical, matching ghost)",
     placedBBox.sizeY > placedBBox.sizeX * 2,
-    `Y=${placedBBox.sizeY} X=${placedBBox.sizeX}`
+    `Y=${placedBBox.sizeY} X=${placedBBox.sizeX}`,
   );
   assert(
     "Placed part is taller in Y than Z (vertical, matching ghost)",
     placedBBox.sizeY > placedBBox.sizeZ * 2,
-    `Y=${placedBBox.sizeY} Z=${placedBBox.sizeZ}`
+    `Y=${placedBBox.sizeY} Z=${placedBBox.sizeZ}`,
   );
 }
 
 // Step 4: If both exist, compare that the tallest axis is the same
 if (ghostBBox && placedBBox) {
-  const ghostTallAxis = ghostBBox.sizeY > ghostBBox.sizeX && ghostBBox.sizeY > ghostBBox.sizeZ ? "Y"
-    : ghostBBox.sizeX > ghostBBox.sizeZ ? "X" : "Z";
-  const placedTallAxis = placedBBox.sizeY > placedBBox.sizeX && placedBBox.sizeY > placedBBox.sizeZ ? "Y"
-    : placedBBox.sizeX > placedBBox.sizeZ ? "X" : "Z";
+  const ghostTallAxis =
+    ghostBBox.sizeY > ghostBBox.sizeX && ghostBBox.sizeY > ghostBBox.sizeZ
+      ? "Y"
+      : ghostBBox.sizeX > ghostBBox.sizeZ
+        ? "X"
+        : "Z";
+  const placedTallAxis =
+    placedBBox.sizeY > placedBBox.sizeX && placedBBox.sizeY > placedBBox.sizeZ
+      ? "Y"
+      : placedBBox.sizeX > placedBBox.sizeZ
+        ? "X"
+        : "Z";
   assert(
     `Ghost and placed part share tallest axis`,
     ghostTallAxis === placedTallAxis,
-    `ghost=${ghostTallAxis} placed=${placedTallAxis}`
+    `ghost=${ghostTallAxis} placed=${placedTallAxis}`,
   );
 }
 
@@ -685,7 +735,10 @@ const canPlaceResults = await page.evaluate(() => {
 
 assert("canPlace Y-orientation at [0,0,0] succeeds", canPlaceResults.canPlaceY);
 assert("canPlace X-orientation at [0,0,0] succeeds", canPlaceResults.canPlaceX);
-assert("canPlace X-orientation at [1,0,0] fails (blocked by connector at [3,0,0])", !canPlaceResults.cannotPlaceXBlocked);
+assert(
+  "canPlace X-orientation at [1,0,0] fails (blocked by connector at [3,0,0])",
+  !canPlaceResults.cannotPlaceXBlocked,
+);
 
 // Clean up
 await page.evaluate(() => (window as any).__assembly.clear());
@@ -716,13 +769,9 @@ const snapResults = await page.evaluate(() => {
     orientations: [...new Set(orientations)],
     directions: [...new Set(directions)],
     // Check a specific snap: +z socket should produce Z-oriented support at [5,0,6]
-    hasZSnap: points.some(
-      (p: any) => p.orientation === "z" && p.socketDirection === "+z"
-    ),
+    hasZSnap: points.some((p: any) => p.orientation === "z" && p.socketDirection === "+z"),
     // +x socket should produce X-oriented support
-    hasXSnap: points.some(
-      (p: any) => p.orientation === "x" && p.socketDirection === "+x"
-    ),
+    hasXSnap: points.some((p: any) => p.orientation === "x" && p.socketDirection === "+x"),
   };
 });
 
@@ -732,7 +781,7 @@ assert("Snap includes X-oriented candidate (+x socket)", snapResults.hasXSnap);
 assert(
   "Snap has multiple orientations",
   snapResults.orientations.length >= 2,
-  `orientations: ${JSON.stringify(snapResults.orientations)}`
+  `orientations: ${JSON.stringify(snapResults.orientations)}`,
 );
 
 // Test findBestSnap returns the nearest one
@@ -743,7 +792,11 @@ const bestSnapResult = await page.evaluate(() => {
   // Cursor near the +x socket of the connector at [5,0,5]
   const best = snap.findBestSnap(a, "support-3u", [6, 0, 5], 3);
   return best
-    ? { position: best.position, orientation: best.orientation, direction: best.socketDirection }
+    ? {
+        position: best.position,
+        orientation: best.orientation,
+        direction: best.socketDirection,
+      }
     : null;
 });
 
@@ -752,7 +805,7 @@ if (bestSnapResult) {
   assert(
     "Best snap is X-oriented (nearest to cursor at [6,0,5])",
     bestSnapResult.orientation === "x",
-    `got orientation: ${bestSnapResult.orientation}`
+    `got orientation: ${bestSnapResult.orientation}`,
   );
 }
 
@@ -814,7 +867,7 @@ const bomOriented = await page.evaluate(() => {
 assert(
   "BOM includes lock pins for x-oriented support adjacent to connector",
   bomOriented.some((r) => r.name.includes("Lock Pin")),
-  `BOM rows: ${JSON.stringify(bomOriented)}`
+  `BOM rows: ${JSON.stringify(bomOriented)}`,
 );
 
 // Clean up
@@ -844,7 +897,7 @@ const supportHint = await page.evaluate(() => {
 assert(
   "Support placement hint mentions orientation cycling",
   supportHint.includes("orientation"),
-  `hint: ${supportHint}`
+  `hint: ${supportHint}`,
 );
 
 // Now switch to a connector and check the hint changes
@@ -865,7 +918,7 @@ const connectorHint = await page.evaluate(() => {
 assert(
   "Connector placement hint mentions rotate (not orientation)",
   connectorHint.includes("rotate") && !connectorHint.includes("orientation"),
-  `hint: ${connectorHint}`
+  `hint: ${connectorHint}`,
 );
 
 // Exit placement mode
@@ -1067,12 +1120,12 @@ assert("2D2W has +x snap (horizontal)", lShapeSnap.hasXSnap);
 assert(
   "+z snap position is in front of connector",
   lShapeSnap.zPos && lShapeSnap.zPos[2] === 6,
-  `pos: ${JSON.stringify(lShapeSnap.zPos)}`
+  `pos: ${JSON.stringify(lShapeSnap.zPos)}`,
 );
 assert(
   "+x snap position is right of connector",
   lShapeSnap.xPos && lShapeSnap.xPos[0] === 6,
-  `pos: ${JSON.stringify(lShapeSnap.xPos)}`
+  `pos: ${JSON.stringify(lShapeSnap.xPos)}`,
 );
 assert("+z snap has Z orientation", lShapeSnap.zOrient === "z");
 assert("+x snap has X orientation", lShapeSnap.xOrient === "x");
@@ -1089,10 +1142,22 @@ const lShapePlaceX = await page.evaluate(() => {
 
   // Place the support at the snap position with the snap orientation
   const id = a.addPart("support-5u", xSnap.position, [0, 0, 0], xSnap.orientation);
-  if (!id) return { placed: false, reason: "addPart returned null", pos: xSnap.position, orient: xSnap.orientation };
+  if (!id)
+    return {
+      placed: false,
+      reason: "addPart returned null",
+      pos: xSnap.position,
+      orient: xSnap.orientation,
+    };
 
   // Verify the support occupies the correct cells (extending in +x from [6,0,5])
-  const expectedCells: [number, number, number][] = [[6,0,5],[7,0,5],[8,0,5],[9,0,5],[10,0,5]];
+  const expectedCells: [number, number, number][] = [
+    [6, 0, 5],
+    [7, 0, 5],
+    [8, 0, 5],
+    [9, 0, 5],
+    [10, 0, 5],
+  ];
   const occupancy = expectedCells.map((c) => ({
     cell: c,
     occupied: a.isOccupied(c),
@@ -1106,8 +1171,11 @@ const lShapePlaceX = await page.evaluate(() => {
 });
 
 assert("Support placed at +x snap position", lShapePlaceX.placed === true, JSON.stringify(lShapePlaceX));
-assert("X-oriented support occupies cells [6..10, 0, 5]", lShapePlaceX.allOccupied === true,
-  JSON.stringify(lShapePlaceX.occupancy));
+assert(
+  "X-oriented support occupies cells [6..10, 0, 5]",
+  lShapePlaceX.allOccupied === true,
+  JSON.stringify(lShapePlaceX.occupancy),
+);
 assert("Connector cell [5,0,5] still occupied", lShapePlaceX.connectorCellStillConnector === true);
 
 // Now place a support in the +z slot and verify the snap only offers nothing (both filled)
@@ -1126,7 +1194,11 @@ const lShapeOpen = await page.evaluate(() => {
   return { totalCandidates: points.length, hasZSnap, hasXSnap };
 });
 
-assert("After filling both slots, 0 snap candidates remain", lShapeOpen.totalCandidates === 0, `got ${lShapeOpen.totalCandidates}`);
+assert(
+  "After filling both slots, 0 snap candidates remain",
+  lShapeOpen.totalCandidates === 0,
+  `got ${lShapeOpen.totalCandidates}`,
+);
 assert("Filled +z slot is no longer offered", !lShapeOpen.hasZSnap);
 assert("Filled +x slot is no longer offered", !lShapeOpen.hasXSnap);
 
@@ -1162,11 +1234,15 @@ const connectorSnapTop = await page.evaluate(() => {
   };
 });
 
-assert("Connector snap finds support top", connectorSnapTop.hasTopSnap,
-  `count=${connectorSnapTop.count}`);
-assert("Connector snap top is at [5,5,5]",
-  connectorSnapTop.topPos && connectorSnapTop.topPos[0] === 5 && connectorSnapTop.topPos[1] === 5 && connectorSnapTop.topPos[2] === 5,
-  `pos: ${JSON.stringify(connectorSnapTop.topPos)}`);
+assert("Connector snap finds support top", connectorSnapTop.hasTopSnap, `count=${connectorSnapTop.count}`);
+assert(
+  "Connector snap top is at [5,5,5]",
+  connectorSnapTop.topPos &&
+    connectorSnapTop.topPos[0] === 5 &&
+    connectorSnapTop.topPos[1] === 5 &&
+    connectorSnapTop.topPos[2] === 5,
+  `pos: ${JSON.stringify(connectorSnapTop.topPos)}`,
+);
 assert("Bottom snap excluded (below ground)", !connectorSnapTop.hasBottomSnap);
 
 // Also test with support-10u (top at y=9, connector at y=10)
@@ -1185,12 +1261,16 @@ const connectorSnapTall = await page.evaluate(() => {
   };
 });
 
-assert("Connector snap finds top of tall (10u) support",
+assert(
+  "Connector snap finds top of tall (10u) support",
   connectorSnapTall.hasTopSnap,
-  `pos: ${JSON.stringify(connectorSnapTall.topPos)}`);
-assert("Connector at top of 10u support is at [5,10,5]",
+  `pos: ${JSON.stringify(connectorSnapTall.topPos)}`,
+);
+assert(
+  "Connector at top of 10u support is at [5,10,5]",
   connectorSnapTall.topPos && connectorSnapTall.topPos[1] === 10,
-  `pos: ${JSON.stringify(connectorSnapTall.topPos)}`);
+  `pos: ${JSON.stringify(connectorSnapTall.topPos)}`,
+);
 
 // Clean up
 await page.evaluate(() => (window as any).__assembly.clear());
@@ -1233,11 +1313,12 @@ const raySnap = await page.evaluate(() => {
 });
 
 assert("No top snap without ray (cursor XZ too far)", !raySnap.hasTopWithoutRay);
-assert("Top snap found with ray proximity", raySnap.hasTopWithRay,
-  `pos: ${JSON.stringify(raySnap.topPos)}`);
-assert("Ray snap position is [5,10,5]",
+assert("Top snap found with ray proximity", raySnap.hasTopWithRay, `pos: ${JSON.stringify(raySnap.topPos)}`);
+assert(
+  "Ray snap position is [5,10,5]",
   raySnap.topPos && raySnap.topPos[0] === 5 && raySnap.topPos[1] === 10 && raySnap.topPos[2] === 5,
-  `pos: ${JSON.stringify(raySnap.topPos)}`);
+  `pos: ${JSON.stringify(raySnap.topPos)}`,
+);
 
 // Clean up
 await page.evaluate(() => (window as any).__assembly.clear());

--- a/configurator/scripts/screenshot.ts
+++ b/configurator/scripts/screenshot.ts
@@ -31,7 +31,10 @@ const server = Bun.serve({
     if (pathname.startsWith("/src/") && /\.(tsx?|jsx?)$/.test(pathname)) {
       const mapped = pathname.replace("/src/", "").replace(".tsx", ".js").replace(".ts", ".js");
       const file = Bun.file(join(DIST_DIR, mapped));
-      if (await file.exists()) return new Response(file, { headers: { "Content-Type": "application/javascript" } });
+      if (await file.exists())
+        return new Response(file, {
+          headers: { "Content-Type": "application/javascript" },
+        });
     }
 
     if (pathname !== "/" && pathname !== "/index.html") {
@@ -47,10 +50,9 @@ const server = Bun.serve({
     }
 
     const html = await Bun.file(join(PROJECT_ROOT, "index.html")).text();
-    return new Response(
-      html.replace('src="/src/main.tsx"', 'src="/src/main.js"'),
-      { headers: { "Content-Type": "text/html" } }
-    );
+    return new Response(html.replace('src="/src/main.tsx"', 'src="/src/main.js"'), {
+      headers: { "Content-Type": "text/html" },
+    });
   },
 });
 
@@ -81,10 +83,10 @@ await page.evaluate(() => {
   asm.clear();
 
   // Bottom layer: 4 foot connectors at corners (rotate arms toward adjacent supports)
-  asm.addPart("connector-3d3w-foot", [0, 0, 0], [0, 0, 0]);     // arms: +x, +y, +z
-  asm.addPart("connector-3d3w-foot", [5, 0, 0], [0, 270, 0]);   // arms: -x, +y, +z
-  asm.addPart("connector-3d3w-foot", [0, 0, 5], [0, 90, 0]);    // arms: +x, +y, -z
-  asm.addPart("connector-3d3w-foot", [5, 0, 5], [0, 180, 0]);   // arms: -x, +y, -z
+  asm.addPart("connector-3d3w-foot", [0, 0, 0], [0, 0, 0]); // arms: +x, +y, +z
+  asm.addPart("connector-3d3w-foot", [5, 0, 0], [0, 270, 0]); // arms: -x, +y, +z
+  asm.addPart("connector-3d3w-foot", [0, 0, 5], [0, 90, 0]); // arms: +x, +y, -z
+  asm.addPart("connector-3d3w-foot", [5, 0, 5], [0, 180, 0]); // arms: -x, +y, -z
 
   // Vertical supports on each corner
   asm.addPart("support-5u", [0, 1, 0], [0, 0, 0], "y");
@@ -101,10 +103,10 @@ await page.evaluate(() => {
   asm.addPart("support-4u", [5, 0, 1], [0, 0, 0], "z");
 
   // Top connectors (arms face down toward vertical supports + out toward horizontal)
-  asm.addPart("connector-3d3w", [0, 6, 0], [90, 0, 0]);       // arms: +x, -y, +z
-  asm.addPart("connector-3d3w", [5, 6, 0], [90, 270, 0]);     // arms: -x, -y, +z
-  asm.addPart("connector-3d3w", [0, 6, 5], [180, 0, 0]);      // arms: +x, -y, -z
-  asm.addPart("connector-3d3w", [5, 6, 5], [180, 270, 0]);    // arms: -x, -y, -z
+  asm.addPart("connector-3d3w", [0, 6, 0], [90, 0, 0]); // arms: +x, -y, +z
+  asm.addPart("connector-3d3w", [5, 6, 0], [90, 270, 0]); // arms: -x, -y, +z
+  asm.addPart("connector-3d3w", [0, 6, 5], [180, 0, 0]); // arms: +x, -y, -z
+  asm.addPart("connector-3d3w", [5, 6, 5], [180, 270, 0]); // arms: -x, -y, -z
 
   // Top horizontal supports along X axis (front and back)
   asm.addPart("support-4u", [1, 6, 0], [0, 0, 0], "x");
@@ -129,9 +131,14 @@ const layoutInfo = await page.evaluate(() => {
     const cs = getComputedStyle(el);
     return {
       selector: sel,
-      x: r.x, y: r.y, width: r.width, height: r.height,
-      display: cs.display, flexDirection: cs.flexDirection,
-      overflow: cs.overflow, position: cs.position,
+      x: r.x,
+      y: r.y,
+      width: r.width,
+      height: r.height,
+      display: cs.display,
+      flexDirection: cs.flexDirection,
+      overflow: cs.overflow,
+      position: cs.position,
     };
   };
   return {
@@ -150,7 +157,9 @@ const layoutInfo = await page.evaluate(() => {
 console.log("\n=== Layout Info ===");
 for (const [key, val] of Object.entries(layoutInfo)) {
   if (val) {
-    console.log(`${key}: ${val.width}x${val.height} at (${val.x},${val.y}) display=${val.display} flex=${val.flexDirection}`);
+    console.log(
+      `${key}: ${val.width}x${val.height} at (${val.x},${val.y}) display=${val.display} flex=${val.flexDirection}`,
+    );
   } else {
     console.log(`${key}: NOT FOUND`);
   }

--- a/configurator/scripts/test-browser.ts
+++ b/configurator/scripts/test-browser.ts
@@ -28,7 +28,10 @@ if (!buildResult.success) {
   process.exit(1);
 }
 
-console.log("Build succeeded:", buildResult.outputs.map(o => o.path));
+console.log(
+  "Build succeeded:",
+  buildResult.outputs.map((o) => o.path),
+);
 
 // Step 2: Check output files exist
 const mainJs = join(DIST_DIR, "main.js");
@@ -109,7 +112,7 @@ const server = Bun.serve({
     const indexContent = await Bun.file(indexPath).text();
     const rewritten = indexContent.replace(
       '<script type="module" src="/src/main.tsx"></script>',
-      '<script type="module" src="/src/main.js"></script>'
+      '<script type="module" src="/src/main.js"></script>',
     );
     return new Response(rewritten, {
       headers: { "Content-Type": "text/html" },

--- a/configurator/scripts/test-render.ts
+++ b/configurator/scripts/test-render.ts
@@ -37,7 +37,10 @@ const server = Bun.serve({
     if (pathname.startsWith("/src/")) {
       const mapped = pathname.replace("/src/", "").replace(".tsx", ".js").replace(".ts", ".js");
       const file = Bun.file(join(DIST_DIR, mapped));
-      if (await file.exists()) return new Response(file, { headers: { "Content-Type": "application/javascript" } });
+      if (await file.exists())
+        return new Response(file, {
+          headers: { "Content-Type": "application/javascript" },
+        });
     }
 
     if (pathname !== "/" && pathname !== "/index.html") {
@@ -48,10 +51,9 @@ const server = Bun.serve({
     }
 
     const html = await Bun.file(join(PROJECT_ROOT, "index.html")).text();
-    return new Response(
-      html.replace('src="/src/main.tsx"', 'src="/src/main.js"'),
-      { headers: { "Content-Type": "text/html" } }
-    );
+    return new Response(html.replace('src="/src/main.tsx"', 'src="/src/main.js"'), {
+      headers: { "Content-Type": "text/html" },
+    });
   },
 });
 

--- a/configurator/src/assembly/AssemblyState.ts
+++ b/configurator/src/assembly/AssemblyState.ts
@@ -19,10 +19,13 @@ function gridKeysForCell(pos: GridPosition): string[] {
   if (pos[1] % 1 !== 0) yVals.push(Math.floor(pos[1]) + 1);
   if (pos[2] % 1 !== 0) zVals.push(Math.floor(pos[2]) + 1);
   const keys: string[] = [];
-  for (const x of xVals)
-    for (const y of yVals)
-      for (const z of zVals)
+  for (const x of xVals) {
+    for (const y of yVals) {
+      for (const z of zVals) {
         keys.push(`${x},${y},${z}`);
+      }
+    }
+  }
   return keys;
 }
 
@@ -45,7 +48,12 @@ export class AssemblyState {
   /** Maps "x,y,z" grid key → instance IDs at that cell */
   gridOccupancy: Map<string, string[]> = new Map();
   private listeners: Set<() => void> = new Set();
-  private cachedSnapshot: AssemblySnapshot = { parts: [], snapEnabled: true, showCollisions: false, fineMeshCollisions: false };
+  private cachedSnapshot: AssemblySnapshot = {
+    parts: [],
+    snapEnabled: true,
+    showCollisions: false,
+    fineMeshCollisions: false,
+  };
 
   /** When true, parts snap to nearby connection points during placement/drag */
   snapEnabled: boolean = true;
@@ -63,13 +71,24 @@ export class AssemblyState {
         if (settings.showCollisions !== undefined) this.showCollisions = !!settings.showCollisions;
         if (settings.fineMeshCollisions !== undefined) this.fineMeshCollisions = !!settings.fineMeshCollisions;
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   private persistSettings() {
     try {
-      localStorage.setItem(SETTINGS_KEY, JSON.stringify({ snapEnabled: this.snapEnabled, showCollisions: this.showCollisions, fineMeshCollisions: this.fineMeshCollisions }));
-    } catch { /* ignore */ }
+      localStorage.setItem(
+        SETTINGS_KEY,
+        JSON.stringify({
+          snapEnabled: this.snapEnabled,
+          showCollisions: this.showCollisions,
+          fineMeshCollisions: this.fineMeshCollisions,
+        }),
+      );
+    } catch {
+      /* ignore */
+    }
   }
 
   setSnapEnabled(value: boolean) {

--- a/configurator/src/assembly/collision.ts
+++ b/configurator/src/assembly/collision.ts
@@ -77,9 +77,15 @@ function isValidPullThroughCell(ids: string[], assembly: AssemblyState): boolean
 
   for (const id of ids) {
     const part = assembly.getPartById(id);
-    if (!part) { otherCount++; continue; }
+    if (!part) {
+      otherCount++;
+      continue;
+    }
     const def = getPartDefinition(part.definitionId);
-    if (!def) { otherCount++; continue; }
+    if (!def) {
+      otherCount++;
+      continue;
+    }
 
     if (def.category === "connector" && def.pullThroughAxis) {
       ptConnectorCount++;

--- a/configurator/src/assembly/grid-utils.ts
+++ b/configurator/src/assembly/grid-utils.ts
@@ -8,10 +8,7 @@ import type { GridPosition, Axis, Direction, Rotation3, RotationStep } from "../
  * orientation "x" -> swap Y and X: [0,i,0] -> [i,0,0]
  * orientation "z" -> swap Y and Z: [0,i,0] -> [0,0,i]
  */
-export function transformCell(
-  cell: GridPosition,
-  orientation: Axis,
-): GridPosition {
+export function transformCell(cell: GridPosition, orientation: Axis): GridPosition {
   switch (orientation) {
     case "y":
       return cell;
@@ -26,18 +23,10 @@ export function transformCell(
  * Get all world-space grid cells a part would occupy at a position
  * with a given orientation.
  */
-export function getWorldCells(
-  cells: GridPosition[],
-  position: GridPosition,
-  orientation: Axis = "y",
-): GridPosition[] {
+export function getWorldCells(cells: GridPosition[], position: GridPosition, orientation: Axis = "y"): GridPosition[] {
   return cells.map((cell) => {
     const t = transformCell(cell, orientation);
-    return [
-      position[0] + t[0],
-      position[1] + t[1],
-      position[2] + t[2],
-    ] as GridPosition;
+    return [position[0] + t[0], position[1] + t[1], position[2] + t[2]] as GridPosition;
   });
 }
 
@@ -69,15 +58,15 @@ export function orientationToRotation(orientation: Axis): Rotation3 {
  *   90° around Y: [x, y, z] → [z, y, -x]
  *   90° around Z: [x, y, z] → [-y, x, z]
  */
-function rotateCellOnce(
-  cell: GridPosition,
-  axis: 0 | 1 | 2,
-): GridPosition {
+function rotateCellOnce(cell: GridPosition, axis: 0 | 1 | 2): GridPosition {
   const [x, y, z] = cell;
   switch (axis) {
-    case 0: return [x, -z, y];   // X-axis
-    case 1: return [z, y, -x];   // Y-axis
-    case 2: return [-y, x, z];   // Z-axis
+    case 0:
+      return [x, -z, y]; // X-axis
+    case 1:
+      return [z, y, -x]; // Y-axis
+    case 2:
+      return [-y, x, z]; // Z-axis
   }
 }
 
@@ -103,10 +92,7 @@ function rotateCellByRotation3(cell: GridPosition, rotation: Rotation3): GridPos
  * Rotate an array of grid cells by a Rotation3.
  * Used to compute world-space occupancy for rotated parts.
  */
-export function rotateGridCells(
-  cells: GridPosition[],
-  rotation: Rotation3,
-): GridPosition[] {
+export function rotateGridCells(cells: GridPosition[], rotation: Rotation3): GridPosition[] {
   // Skip if no rotation
   if (rotation[0] === 0 && rotation[1] === 0 && rotation[2] === 0) {
     return cells;
@@ -128,12 +114,18 @@ export function rotateDirection(direction: Direction, rotation: Rotation3): Dire
 
 function directionToVector(dir: Direction): GridPosition {
   switch (dir) {
-    case "+x": return [1, 0, 0];
-    case "-x": return [-1, 0, 0];
-    case "+y": return [0, 1, 0];
-    case "-y": return [0, -1, 0];
-    case "+z": return [0, 0, 1];
-    case "-z": return [0, 0, -1];
+    case "+x":
+      return [1, 0, 0];
+    case "-x":
+      return [-1, 0, 0];
+    case "+y":
+      return [0, 1, 0];
+    case "-y":
+      return [0, -1, 0];
+    case "+z":
+      return [0, 0, 1];
+    case "-z":
+      return [0, 0, -1];
   }
 }
 
@@ -179,10 +171,7 @@ export function directionToAxis(direction: Direction): Axis {
 }
 
 /** Get the adjacent grid position in a given direction. */
-export function getAdjacentPosition(
-  pos: GridPosition,
-  direction: Direction,
-): GridPosition {
+export function getAdjacentPosition(pos: GridPosition, direction: Direction): GridPosition {
   const [x, y, z] = pos;
   switch (direction) {
     case "+x":

--- a/configurator/src/assembly/mesh-collision.ts
+++ b/configurator/src/assembly/mesh-collision.ts
@@ -49,11 +49,7 @@ function modelCenterOffset(gridCells: GridPosition[], orientation: Axis = "y"): 
   const maxX = Math.max(...cells.map((c) => c[0]));
   const maxY = Math.max(...cells.map((c) => c[1]));
   const maxZ = Math.max(...cells.map((c) => c[2]));
-  return [
-    ((minX + maxX) / 2) * BASE_UNIT,
-    ((minY + maxY) / 2) * BASE_UNIT,
-    ((minZ + maxZ) / 2) * BASE_UNIT,
-  ];
+  return [((minX + maxX) / 2) * BASE_UNIT, ((minY + maxY) / 2) * BASE_UNIT, ((minZ + maxZ) / 2) * BASE_UNIT];
 }
 
 /**
@@ -134,11 +130,13 @@ function isValidPullThroughPair(partA: PlacedPart, partB: PlacedPart): boolean {
   let connRotation: Rotation3;
 
   if (defA.category === "connector" && defA.pullThroughAxis && defB.category === "support") {
-    connector = partA; support = partB;
+    connector = partA;
+    support = partB;
     ptAxisRaw = defA.pullThroughAxis;
     connRotation = partA.rotation ?? [0, 0, 0];
   } else if (defB.category === "connector" && defB.pullThroughAxis && defA.category === "support") {
-    connector = partB; support = partA;
+    connector = partB;
+    support = partA;
     ptAxisRaw = defB.pullThroughAxis;
     connRotation = partB.rotation ?? [0, 0, 0];
   } else {
@@ -174,10 +172,7 @@ function isValidPullThroughPair(partA: PlacedPart, partB: PlacedPart): boolean {
 }
 
 /** Compute world-space AABB for a part */
-function getPartWorldAABB(
-  part: PlacedPart,
-  mat: THREE.Matrix4,
-): THREE.Box3 | undefined {
+function getPartWorldAABB(part: PlacedPart, mat: THREE.Matrix4): THREE.Box3 | undefined {
   const geo = getGeometryForPart(part.definitionId);
   if (!geo) return undefined;
   geo.computeBoundingBox();
@@ -204,10 +199,7 @@ interface PartCollisionData {
  * 3. AABB mid-phase: skip pairs whose world bounding boxes don't overlap
  * 4. BVH narrow phase: actual mesh intersection test (yielded)
  */
-export async function detectCollidingPartIds(
-  assembly: AssemblyState,
-  signal?: AbortSignal,
-): Promise<Set<string>> {
+export async function detectCollidingPartIds(assembly: AssemblyState, signal?: AbortSignal): Promise<Set<string>> {
   // Broad phase: collect candidate pairs from grid occupancy
   const candidatePairs = new Set<string>();
   for (const [, ids] of assembly.gridOccupancy) {
@@ -229,11 +221,20 @@ export async function detectCollidingPartIds(
   function getPartData(id: string): PartCollisionData | null {
     if (partDataCache.has(id)) return partDataCache.get(id)!;
     const part = assembly.getPartById(id);
-    if (!part) { partDataCache.set(id, null); return null; }
+    if (!part) {
+      partDataCache.set(id, null);
+      return null;
+    }
     const mat = getPartWorldMatrix(part);
-    if (!mat) { partDataCache.set(id, null); return null; }
+    if (!mat) {
+      partDataCache.set(id, null);
+      return null;
+    }
     const aabb = getPartWorldAABB(part, mat);
-    if (!aabb) { partDataCache.set(id, null); return null; }
+    if (!aabb) {
+      partDataCache.set(id, null);
+      return null;
+    }
     const invMat = mat.clone().invert();
     const data: PartCollisionData = { part, mat, invMat, aabb };
     partDataCache.set(id, data);
@@ -243,7 +244,11 @@ export async function detectCollidingPartIds(
   const collidingIds = new Set<string>();
   const pairs = Array.from(candidatePairs);
   const BATCH_SIZE = 10;
-  let ptSkipped = 0, aabbSkipped = 0, bvhTested = 0, bvhHit = 0, noGeoSkipped = 0;
+  let ptSkipped = 0,
+    aabbSkipped = 0,
+    bvhTested = 0,
+    bvhHit = 0,
+    noGeoSkipped = 0;
 
   for (let batch = 0; batch < pairs.length; batch += BATCH_SIZE) {
     if (signal?.aborted) return new Set();
@@ -259,20 +264,29 @@ export async function detectCollidingPartIds(
       const dataB = getPartData(idB);
       if (!dataA || !dataB) continue;
 
-      if (isValidPullThroughPair(dataA.part, dataB.part)) { ptSkipped++; continue; }
+      if (isValidPullThroughPair(dataA.part, dataB.part)) {
+        ptSkipped++;
+        continue;
+      }
 
       // Shrink AABBs by a small tolerance to avoid false positives from
       // parts that merely touch at a shared boundary (e.g. adjacent connector + support)
       const AABB_TOLERANCE = 0.75; // mm
       const shrunkA = dataA.aabb.clone().expandByScalar(-AABB_TOLERANCE);
       const shrunkB = dataB.aabb.clone().expandByScalar(-AABB_TOLERANCE);
-      if (!shrunkA.intersectsBox(shrunkB)) { aabbSkipped++; continue; }
+      if (!shrunkA.intersectsBox(shrunkB)) {
+        aabbSkipped++;
+        continue;
+      }
 
       // Ensure both geometries have BVH for fast dual-tree traversal
       ensureBVH(dataA.part.definitionId);
       const bvhB = ensureBVH(dataB.part.definitionId);
       const geoA = getGeometryForPart(dataA.part.definitionId);
-      if (!bvhB || !geoA) { noGeoSkipped++; continue; }
+      if (!bvhB || !geoA) {
+        noGeoSkipped++;
+        continue;
+      }
 
       bvhTested++;
       const trisA = geoA.index ? geoA.index.count / 3 : geoA.attributes.position.count / 3;
@@ -294,7 +308,9 @@ export async function detectCollidingPartIds(
       const hit = bvhB.intersectsGeometry(geoA, matAToB);
       const dt = performance.now() - t0;
       if (dt > 10) {
-        console.warn(`[MeshCollision] SLOW pair: ${dataA.part.definitionId} (${trisA} tris) vs ${dataB.part.definitionId} (${trisB} tris) = ${dt.toFixed(1)}ms hit=${hit}`);
+        console.warn(
+          `[MeshCollision] SLOW pair: ${dataA.part.definitionId} (${trisA} tris) vs ${dataB.part.definitionId} (${trisB} tris) = ${dt.toFixed(1)}ms hit=${hit}`,
+        );
       }
       if (hit) {
         bvhHit++;
@@ -309,6 +325,8 @@ export async function detectCollidingPartIds(
     }
   }
 
-  console.log(`[MeshCollision] ptSkipped=${ptSkipped} aabbSkipped=${aabbSkipped} noGeo=${noGeoSkipped} bvhTested=${bvhTested} bvhHit=${bvhHit} colliding=${collidingIds.size}`);
+  console.log(
+    `[MeshCollision] ptSkipped=${ptSkipped} aabbSkipped=${aabbSkipped} noGeo=${noGeoSkipped} bvhTested=${bvhTested} bvhHit=${bvhHit} colliding=${collidingIds.size}`,
+  );
   return collidingIds;
 }

--- a/configurator/src/assembly/snap.ts
+++ b/configurator/src/assembly/snap.ts
@@ -297,9 +297,7 @@ export function computeAutoRotation(
   if (!def) return fallbackRotation;
 
   // Get base arm directions from connection points
-  const baseArmDirs = def.connectionPoints
-    .filter(cp => cp.type === "female")
-    .map(cp => cp.direction);
+  const baseArmDirs = def.connectionPoints.filter((cp) => cp.type === "female").map((cp) => cp.direction);
 
   if (baseArmDirs.length === 0) return fallbackRotation;
 
@@ -310,7 +308,10 @@ export function computeAutoRotation(
 
   // Distance between two rotations (minimum steps to go from one to the other)
   const rotDist = (a: Rotation3, b: Rotation3) => {
-    const d = (v1: number, v2: number) => { const diff = ((v1 - v2) % 360 + 360) % 360; return Math.min(diff, 360 - diff) / 90; };
+    const d = (v1: number, v2: number) => {
+      const diff = (((v1 - v2) % 360) + 360) % 360;
+      return Math.min(diff, 360 - diff) / 90;
+    };
     return d(a[0], b[0]) + d(a[1], b[1]) + d(a[2], b[2]);
   };
 
@@ -320,7 +321,7 @@ export function computeAutoRotation(
         const rotation: Rotation3 = [rx, ry, rz];
 
         // Rotate all arm directions by this rotation
-        const rotatedArms = baseArmDirs.map(d => rotateDirection(d, rotation));
+        const rotatedArms = baseArmDirs.map((d) => rotateDirection(d, rotation));
 
         // Count how many needed directions are covered
         let coverage = 0;
@@ -354,7 +355,14 @@ export function findBestConnectorSnap(
   ray?: GridRay,
   connectorRotation?: Rotation3,
 ): SnapCandidate | null {
-  const candidates = findConnectorSnapPoints(assembly, connectorDefId, cursorGridPos, snapRadius, ray, connectorRotation);
+  const candidates = findConnectorSnapPoints(
+    assembly,
+    connectorDefId,
+    cursorGridPos,
+    snapRadius,
+    ray,
+    connectorRotation,
+  );
   if (candidates.length === 0) return null;
 
   const best = candidates[0];
@@ -365,7 +373,11 @@ export function findBestConnectorSnap(
   const seen = new Set<Direction>();
   const neededDirs: Direction[] = [];
   for (const c of candidates) {
-    if (c.position[0] === best.position[0] && c.position[1] === best.position[1] && c.position[2] === best.position[2]) {
+    if (
+      c.position[0] === best.position[0] &&
+      c.position[1] === best.position[1] &&
+      c.position[2] === best.position[2]
+    ) {
       const opp = oppositeDir(c.socketDirection);
       if (!seen.has(opp)) {
         seen.add(opp);

--- a/configurator/src/components/App.tsx
+++ b/configurator/src/components/App.tsx
@@ -35,7 +35,7 @@ const INVENTORY_STORAGE_KEY = "homeracker-inventory";
 // Restore custom parts (IndexedDB) THEN assembly (localStorage or URL hash).
 // Custom part definitions must exist before deserialize() resolves their IDs.
 const initPromise = restoreCustomParts()
-  .catch(() => { }) // IndexedDB may be unavailable
+  .catch(() => {}) // IndexedDB may be unavailable
   .then(async () => {
     // URL hash takes priority over localStorage
     if (location.hash.startsWith("#scene=")) {
@@ -593,7 +593,7 @@ export function App() {
         color: p.color,
       })),
     };
-    navigator.clipboard.writeText(JSON.stringify({ homeracker: "clipboard", ...clipboard })).catch(() => { });
+    navigator.clipboard.writeText(JSON.stringify({ homeracker: "clipboard", ...clipboard })).catch(() => {});
     setToast(`Copied ${parts.length} part(s)`);
     setTimeout(() => setToast(null), 2000);
   }, [selectedPartIds]);

--- a/configurator/src/components/App.tsx
+++ b/configurator/src/components/App.tsx
@@ -7,10 +7,22 @@ import { AssemblyState } from "../assembly/AssemblyState";
 import { HistoryManager, type Command } from "../assembly/HistoryManager";
 import type { InteractionMode, GridPosition, PlacedPart, Axis, Rotation3, RotationStep, ClipboardData } from "../types";
 import { getPartDefinition } from "../data/catalog";
-import { findBestSnap, findSnapPoints, findBestConnectorSnap, findConnectorSnapPoints, computeAutoRotation } from "../assembly/snap";
+import {
+  findBestSnap,
+  findSnapPoints,
+  findBestConnectorSnap,
+  findConnectorSnapPoints,
+  computeAutoRotation,
+} from "../assembly/snap";
 import { computeGroundLift, nextOrientation } from "../assembly/grid-utils";
 import { detectCollidingPartIds, detectCollidingPartIdsMesh } from "../assembly/collision";
-import { restoreCustomParts, importModelFile, isCustomPart, getEmbeddedCustomParts, restoreEmbeddedCustomParts } from "../data/custom-parts";
+import {
+  restoreCustomParts,
+  importModelFile,
+  isCustomPart,
+  getEmbeddedCustomParts,
+  restoreEmbeddedCustomParts,
+} from "../data/custom-parts";
 import { encodeAssemblyToHash, decodeAssemblyFromHash, hasCustomParts } from "../sharing/url-sharing";
 
 // Global singleton instances
@@ -23,7 +35,7 @@ const INVENTORY_STORAGE_KEY = "homeracker-inventory";
 // Restore custom parts (IndexedDB) THEN assembly (localStorage or URL hash).
 // Custom part definitions must exist before deserialize() resolves their IDs.
 const initPromise = restoreCustomParts()
-  .catch(() => {}) // IndexedDB may be unavailable
+  .catch(() => { }) // IndexedDB may be unavailable
   .then(async () => {
     // URL hash takes priority over localStorage
     if (location.hash.startsWith("#scene=")) {
@@ -53,11 +65,20 @@ assembly.subscribe(() => {
 
 // Expose for e2e testing
 (window as any).__assembly = assembly;
-(window as any).__snap = { findBestSnap, findSnapPoints, findBestConnectorSnap, findConnectorSnapPoints, computeAutoRotation };
+(window as any).__snap = {
+  findBestSnap,
+  findSnapPoints,
+  findBestConnectorSnap,
+  findConnectorSnapPoints,
+  computeAutoRotation,
+};
 (window as any).__importSTL = importModelFile; // backward compat for e2e
 (window as any).__importModel = importModelFile;
 (window as any).__computeGroundLift = computeGroundLift;
-(window as any).__collision = { detectCollidingPartIds, detectCollidingPartIdsMesh };
+(window as any).__collision = {
+  detectCollidingPartIds,
+  detectCollidingPartIdsMesh,
+};
 
 export function App() {
   const [ready, setReady] = useState(false);
@@ -81,7 +102,9 @@ export function App() {
     setInventory(newInventory);
     try {
       localStorage.setItem(INVENTORY_STORAGE_KEY, JSON.stringify(newInventory));
-    } catch { /* ignore quota errors */ }
+    } catch {
+      /* ignore quota errors */
+    }
   }, []);
 
   // Wait for custom parts + assembly restore before rendering
@@ -91,7 +114,9 @@ export function App() {
       try {
         const saved = localStorage.getItem(INVENTORY_STORAGE_KEY);
         if (saved) setInventory(JSON.parse(saved));
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
       setReady(true);
     });
   }, []);
@@ -99,7 +124,7 @@ export function App() {
   // Subscribe to assembly changes for re-renders
   const snapshot = useSyncExternalStore(
     (cb) => assembly.subscribe(cb),
-    () => assembly.getSnapshot()
+    () => assembly.getSnapshot(),
   );
 
   const handleSelectPart = useCallback((definitionId: string) => {
@@ -108,7 +133,12 @@ export function App() {
   }, []);
 
   const handlePlacePart = useCallback(
-    (definitionId: string, position: GridPosition, rotation: PlacedPart["rotation"] = [0, 0, 0], orientation?: Axis) => {
+    (
+      definitionId: string,
+      position: GridPosition,
+      rotation: PlacedPart["rotation"] = [0, 0, 0],
+      orientation?: Axis,
+    ) => {
       const cmd: Command = {
         description: `Place ${definitionId}`,
         execute() {
@@ -122,14 +152,14 @@ export function App() {
               p.definitionId === definitionId &&
               p.position[0] === position[0] &&
               p.position[1] === position[1] &&
-              p.position[2] === position[2]
+              p.position[2] === position[2],
           );
           if (match) assembly.removePart(match.instanceId);
         },
       };
       history.execute(cmd);
     },
-    []
+    [],
   );
 
   const handleDeleteSelected = useCallback(() => {
@@ -167,9 +197,7 @@ export function App() {
         part.position[1] === newPosition[1] &&
         part.position[2] === newPosition[2];
       const sameRotation =
-        part.rotation[0] === rotation[0] &&
-        part.rotation[1] === rotation[1] &&
-        part.rotation[2] === rotation[2];
+        part.rotation[0] === rotation[0] && part.rotation[1] === rotation[1] && part.rotation[2] === rotation[2];
       const sameOrientation = part.orientation === orientation;
       if (samePosition && sameRotation && sameOrientation) return; // No-op
 
@@ -193,7 +221,7 @@ export function App() {
               p.definitionId === definitionId &&
               p.position[0] === newPosition[0] &&
               p.position[1] === newPosition[1] &&
-              p.position[2] === newPosition[2]
+              p.position[2] === newPosition[2],
           );
           if (match) {
             assembly.removePart(match.instanceId);
@@ -203,7 +231,7 @@ export function App() {
       };
       history.execute(cmd);
     },
-    []
+    [],
   );
 
   const handleMoveSelectedParts = useCallback(
@@ -219,7 +247,17 @@ export function App() {
       if (delta[0] === 0 && delta[1] === 0 && delta[2] === 0 && !newRotation && !newOrientation) return;
 
       // Snapshot all selected parts before moving
-      const partsToMove: { id: string; def: string; oldPos: GridPosition; oldRot: Rotation3; oldOrient?: Axis; color?: string; newPos: GridPosition; newRot: Rotation3; newOrient?: Axis }[] = [];
+      const partsToMove: {
+        id: string;
+        def: string;
+        oldPos: GridPosition;
+        oldRot: Rotation3;
+        oldOrient?: Axis;
+        color?: string;
+        newPos: GridPosition;
+        newRot: Rotation3;
+        newOrient?: Axis;
+      }[] = [];
       for (const id of selectedPartIds) {
         const part = assembly.getPartById(id);
         if (!part) continue;
@@ -231,7 +269,9 @@ export function App() {
           oldRot: part.rotation,
           oldOrient: part.orientation,
           color: part.color,
-          newPos: isPrimary ? newPosition : [part.position[0] + delta[0], part.position[1] + delta[1], part.position[2] + delta[2]],
+          newPos: isPrimary
+            ? newPosition
+            : [part.position[0] + delta[0], part.position[1] + delta[1], part.position[2] + delta[2]],
           newRot: isPrimary ? (newRotation ?? part.rotation) : part.rotation,
           newOrient: isPrimary ? (newOrientation ?? part.orientation) : part.orientation,
         });
@@ -249,8 +289,11 @@ export function App() {
           const allParts = assembly.getAllParts();
           for (const p of partsToMove) {
             const match = allParts.find(
-              (ap) => ap.definitionId === p.def &&
-                ap.position[0] === p.newPos[0] && ap.position[1] === p.newPos[1] && ap.position[2] === p.newPos[2]
+              (ap) =>
+                ap.definitionId === p.def &&
+                ap.position[0] === p.newPos[0] &&
+                ap.position[1] === p.newPos[1] &&
+                ap.position[2] === p.newPos[2],
             );
             if (match) assembly.removePart(match.instanceId);
           }
@@ -259,14 +302,21 @@ export function App() {
       };
       history.execute(cmd);
     },
-    [selectedPartIds]
+    [selectedPartIds],
   );
 
   const handleNudgeParts = useCallback(
     (dx: number, dy: number, dz: number) => {
       if (selectedPartIds.size === 0) return;
 
-      const partsToNudge: { id: string; def: string; oldPos: GridPosition; rot: Rotation3; orient?: Axis; color?: string }[] = [];
+      const partsToNudge: {
+        id: string;
+        def: string;
+        oldPos: GridPosition;
+        rot: Rotation3;
+        orient?: Axis;
+        color?: string;
+      }[] = [];
       for (const id of selectedPartIds) {
         const part = assembly.getPartById(id);
         if (!part) continue;
@@ -296,8 +346,11 @@ export function App() {
           for (const p of partsToNudge) {
             const newPos: GridPosition = [p.oldPos[0] + dx, p.oldPos[1] + dy, p.oldPos[2] + dz];
             const match = allParts.find(
-              (ap) => ap.definitionId === p.def &&
-                ap.position[0] === newPos[0] && ap.position[1] === newPos[1] && ap.position[2] === newPos[2]
+              (ap) =>
+                ap.definitionId === p.def &&
+                ap.position[0] === newPos[0] &&
+                ap.position[1] === newPos[1] &&
+                ap.position[2] === newPos[2],
             );
             if (match) assembly.removePart(match.instanceId);
           }
@@ -311,24 +364,33 @@ export function App() {
       for (const p of partsToNudge) {
         const newPos: GridPosition = [p.oldPos[0] + dx, p.oldPos[1] + dy, p.oldPos[2] + dz];
         const match = allParts.find(
-          (ap) => ap.definitionId === p.def &&
-            ap.position[0] === newPos[0] && ap.position[1] === newPos[1] && ap.position[2] === newPos[2]
+          (ap) =>
+            ap.definitionId === p.def &&
+            ap.position[0] === newPos[0] &&
+            ap.position[1] === newPos[1] &&
+            ap.position[2] === newPos[2],
         );
         if (match) newIds.add(match.instanceId);
       }
       setSelectedPartIds(newIds);
     },
-    [selectedPartIds]
+    [selectedPartIds],
   );
 
-  const nextStep = (step: RotationStep): RotationStep =>
-    step === 0 ? 90 : step === 90 ? 180 : step === 180 ? 270 : 0;
+  const nextStep = (step: RotationStep): RotationStep => (step === 0 ? 90 : step === 90 ? 180 : step === 180 ? 270 : 0);
 
   const handleRotateSelectedParts = useCallback(
     (axis: 0 | 1 | 2) => {
       if (selectedPartIds.size === 0) return;
 
-      const partsToRotate: { id: string; def: string; pos: GridPosition; oldRot: Rotation3; orient?: Axis; color?: string }[] = [];
+      const partsToRotate: {
+        id: string;
+        def: string;
+        pos: GridPosition;
+        oldRot: Rotation3;
+        orient?: Axis;
+        color?: string;
+      }[] = [];
       for (const id of selectedPartIds) {
         const part = assembly.getPartById(id);
         if (!part) continue;
@@ -359,9 +421,14 @@ export function App() {
             const newRot: Rotation3 = [...p.oldRot];
             newRot[axis] = nextStep(newRot[axis]);
             const match = allParts.find(
-              (ap) => ap.definitionId === p.def &&
-                ap.position[0] === p.pos[0] && ap.position[1] === p.pos[1] && ap.position[2] === p.pos[2] &&
-                ap.rotation[0] === newRot[0] && ap.rotation[1] === newRot[1] && ap.rotation[2] === newRot[2]
+              (ap) =>
+                ap.definitionId === p.def &&
+                ap.position[0] === p.pos[0] &&
+                ap.position[1] === p.pos[1] &&
+                ap.position[2] === p.pos[2] &&
+                ap.rotation[0] === newRot[0] &&
+                ap.rotation[1] === newRot[1] &&
+                ap.rotation[2] === newRot[2],
             );
             if (match) assembly.removePart(match.instanceId);
           }
@@ -376,74 +443,89 @@ export function App() {
         const newRot: Rotation3 = [...p.oldRot];
         newRot[axis] = nextStep(newRot[axis]);
         const match = allParts.find(
-          (ap) => ap.definitionId === p.def &&
-            ap.position[0] === p.pos[0] && ap.position[1] === p.pos[1] && ap.position[2] === p.pos[2] &&
-            ap.rotation[0] === newRot[0] && ap.rotation[1] === newRot[1] && ap.rotation[2] === newRot[2]
+          (ap) =>
+            ap.definitionId === p.def &&
+            ap.position[0] === p.pos[0] &&
+            ap.position[1] === p.pos[1] &&
+            ap.position[2] === p.pos[2] &&
+            ap.rotation[0] === newRot[0] &&
+            ap.rotation[1] === newRot[1] &&
+            ap.rotation[2] === newRot[2],
         );
         if (match) newIds.add(match.instanceId);
       }
       setSelectedPartIds(newIds);
     },
-    [selectedPartIds]
+    [selectedPartIds],
   );
 
-  const handleOrientSelectedParts = useCallback(
-    () => {
-      if (selectedPartIds.size === 0) return;
+  const handleOrientSelectedParts = useCallback(() => {
+    if (selectedPartIds.size === 0) return;
 
-      const partsToOrient: { id: string; def: string; pos: GridPosition; rot: Rotation3; oldOrient: Axis; color?: string }[] = [];
-      for (const id of selectedPartIds) {
-        const part = assembly.getPartById(id);
-        if (!part) continue;
-        const def = getPartDefinition(part.definitionId);
-        if (def?.category !== "support") continue;
-        partsToOrient.push({
-          id,
-          def: part.definitionId,
-          pos: part.position,
-          rot: part.rotation,
-          oldOrient: part.orientation ?? "y",
-          color: part.color,
-        });
-      }
-      if (partsToOrient.length === 0) return;
+    const partsToOrient: {
+      id: string;
+      def: string;
+      pos: GridPosition;
+      rot: Rotation3;
+      oldOrient: Axis;
+      color?: string;
+    }[] = [];
+    for (const id of selectedPartIds) {
+      const part = assembly.getPartById(id);
+      if (!part) continue;
+      const def = getPartDefinition(part.definitionId);
+      if (def?.category !== "support") continue;
+      partsToOrient.push({
+        id,
+        def: part.definitionId,
+        pos: part.position,
+        rot: part.rotation,
+        oldOrient: part.orientation ?? "y",
+        color: part.color,
+      });
+    }
+    if (partsToOrient.length === 0) return;
 
-      const cmd: Command = {
-        description: `Orient ${partsToOrient.length} support(s)`,
-        execute() {
-          for (const p of partsToOrient) assembly.removePart(p.id);
-          for (const p of partsToOrient) {
-            assembly.addPart(p.def, p.pos, p.rot, nextOrientation(p.oldOrient), p.color);
-          }
-        },
-        undo() {
-          const allParts = assembly.getAllParts();
-          for (const p of partsToOrient) {
-            const match = allParts.find(
-              (ap) => ap.definitionId === p.def &&
-                ap.position[0] === p.pos[0] && ap.position[1] === p.pos[1] && ap.position[2] === p.pos[2]
-            );
-            if (match) assembly.removePart(match.instanceId);
-          }
-          for (const p of partsToOrient) assembly.addPart(p.def, p.pos, p.rot, p.oldOrient, p.color);
-        },
-      };
-      history.execute(cmd);
-      // Re-select oriented parts
-      const allParts = assembly.getAllParts();
-      const newIds = new Set<string>(selectedPartIds);
-      for (const p of partsToOrient) {
-        newIds.delete(p.id);
-        const match = allParts.find(
-          (ap) => ap.definitionId === p.def &&
-            ap.position[0] === p.pos[0] && ap.position[1] === p.pos[1] && ap.position[2] === p.pos[2]
-        );
-        if (match) newIds.add(match.instanceId);
-      }
-      setSelectedPartIds(newIds);
-    },
-    [selectedPartIds]
-  );
+    const cmd: Command = {
+      description: `Orient ${partsToOrient.length} support(s)`,
+      execute() {
+        for (const p of partsToOrient) assembly.removePart(p.id);
+        for (const p of partsToOrient) {
+          assembly.addPart(p.def, p.pos, p.rot, nextOrientation(p.oldOrient), p.color);
+        }
+      },
+      undo() {
+        const allParts = assembly.getAllParts();
+        for (const p of partsToOrient) {
+          const match = allParts.find(
+            (ap) =>
+              ap.definitionId === p.def &&
+              ap.position[0] === p.pos[0] &&
+              ap.position[1] === p.pos[1] &&
+              ap.position[2] === p.pos[2],
+          );
+          if (match) assembly.removePart(match.instanceId);
+        }
+        for (const p of partsToOrient) assembly.addPart(p.def, p.pos, p.rot, p.oldOrient, p.color);
+      },
+    };
+    history.execute(cmd);
+    // Re-select oriented parts
+    const allParts = assembly.getAllParts();
+    const newIds = new Set<string>(selectedPartIds);
+    for (const p of partsToOrient) {
+      newIds.delete(p.id);
+      const match = allParts.find(
+        (ap) =>
+          ap.definitionId === p.def &&
+          ap.position[0] === p.pos[0] &&
+          ap.position[1] === p.pos[1] &&
+          ap.position[2] === p.pos[2],
+      );
+      if (match) newIds.add(match.instanceId);
+    }
+    setSelectedPartIds(newIds);
+  }, [selectedPartIds]);
 
   const handleClickPart = useCallback(
     (instanceId: string, shiftKey: boolean) => {
@@ -461,7 +543,7 @@ export function App() {
         });
       }
     },
-    [mode]
+    [mode],
   );
 
   const handleClickEmpty = useCallback(() => {
@@ -481,14 +563,18 @@ export function App() {
     setSelectedPartIds(new Set());
   }, []);
 
-  const handleUndo = useCallback(() => { history.undo(); setSelectedPartIds(new Set()); }, []);
-  const handleRedo = useCallback(() => { history.redo(); setSelectedPartIds(new Set()); }, []);
+  const handleUndo = useCallback(() => {
+    history.undo();
+    setSelectedPartIds(new Set());
+  }, []);
+  const handleRedo = useCallback(() => {
+    history.redo();
+    setSelectedPartIds(new Set());
+  }, []);
 
   const handleCopy = useCallback(() => {
     if (selectedPartIds.size === 0) return;
-    const parts = [...selectedPartIds]
-      .map((id) => assembly.getPartById(id))
-      .filter((p): p is PlacedPart => !!p);
+    const parts = [...selectedPartIds].map((id) => assembly.getPartById(id)).filter((p): p is PlacedPart => !!p);
     if (parts.length === 0) return;
 
     const cx = parts.reduce((s, p) => s + p.position[0], 0) / parts.length;
@@ -501,17 +587,13 @@ export function App() {
     const clipboard: ClipboardData = {
       parts: parts.map((p) => ({
         definitionId: p.definitionId,
-        offset: [
-          p.position[0] - centerX,
-          p.position[1] - centerY,
-          p.position[2] - centerZ,
-        ] as GridPosition,
+        offset: [p.position[0] - centerX, p.position[1] - centerY, p.position[2] - centerZ] as GridPosition,
         rotation: p.rotation,
         orientation: p.orientation,
         color: p.color,
       })),
     };
-    navigator.clipboard.writeText(JSON.stringify({ homeracker: "clipboard", ...clipboard })).catch(() => {});
+    navigator.clipboard.writeText(JSON.stringify({ homeracker: "clipboard", ...clipboard })).catch(() => { });
     setToast(`Copied ${parts.length} part(s)`);
     setTimeout(() => setToast(null), 2000);
   }, [selectedPartIds]);
@@ -534,9 +616,7 @@ export function App() {
       if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
         e.preventDefault();
         handleUndo();
-      } else if (
-        (e.ctrlKey || e.metaKey) && (e.key === "y" || (e.key === "z" && e.shiftKey))
-      ) {
+      } else if ((e.ctrlKey || e.metaKey) && (e.key === "y" || (e.key === "z" && e.shiftKey))) {
         e.preventDefault();
         handleRedo();
       } else if ((e.ctrlKey || e.metaKey) && e.key === "c") {
@@ -650,7 +730,13 @@ export function App() {
         ((a[1] + b[1]) % 360) as Rotation3[1],
         ((a[2] + b[2]) % 360) as Rotation3[2],
       ];
-      const addedParts: { definitionId: string; position: GridPosition; rotation: Rotation3; orientation?: Axis; color?: string }[] = [];
+      const addedParts: {
+        definitionId: string;
+        position: GridPosition;
+        rotation: Rotation3;
+        orientation?: Axis;
+        color?: string;
+      }[] = [];
       for (const cp of clipboard.parts) {
         const pos: GridPosition = [
           targetPosition[0] + cp.offset[0],
@@ -658,7 +744,13 @@ export function App() {
           targetPosition[2] + cp.offset[2],
         ];
         const rot = extraRotation ? addRot(cp.rotation, extraRotation) : cp.rotation;
-        addedParts.push({ definitionId: cp.definitionId, position: pos, rotation: rot, orientation: cp.orientation, color: cp.color });
+        addedParts.push({
+          definitionId: cp.definitionId,
+          position: pos,
+          rotation: rot,
+          orientation: cp.orientation,
+          color: cp.color,
+        });
       }
       if (addedParts.length === 0) return;
 
@@ -679,7 +771,7 @@ export function App() {
                 pp.definitionId === p.definitionId &&
                 pp.position[0] === p.position[0] &&
                 pp.position[1] === p.position[1] &&
-                pp.position[2] === p.position[2]
+                pp.position[2] === p.position[2],
             );
             if (match) assembly.removePart(match.instanceId);
           }
@@ -688,14 +780,17 @@ export function App() {
       history.execute(cmd);
       setMode({ type: "select" });
     },
-    []
+    [],
   );
 
   const handleSetColor = useCallback(
     (color: string | undefined) => {
       if (selectedPartIds.size === 0) return;
 
-      const colorChanges: Array<{ instanceId: string; oldColor: string | undefined }> = [];
+      const colorChanges: Array<{
+        instanceId: string;
+        oldColor: string | undefined;
+      }> = [];
       for (const id of selectedPartIds) {
         const part = assembly.getPartById(id);
         if (part) {
@@ -719,7 +814,7 @@ export function App() {
       };
       history.execute(cmd);
     },
-    [selectedPartIds]
+    [selectedPartIds],
   );
 
   const bom = assembly.getBOM();
@@ -728,7 +823,11 @@ export function App() {
 
   return (
     <div className="app">
-      <Sidebar onSelectPart={handleSelectPart} activeMode={mode} usedDefinitionIds={new Set(snapshot.parts.map((p) => p.definitionId))} />
+      <Sidebar
+        onSelectPart={handleSelectPart}
+        activeMode={mode}
+        usedDefinitionIds={new Set(snapshot.parts.map((p) => p.definitionId))}
+      />
       <div className="main-area">
         <Toolbar
           onUndo={handleUndo}
@@ -772,7 +871,16 @@ export function App() {
           fineMeshCollisions={snapshot.fineMeshCollisions}
         />
       </div>
-      <BOMPanel entries={bom} selectedPartIds={selectedPartIds} parts={snapshot.parts} onFlashPart={handleFlashPart} onFlashDefinition={handleFlashDefinition} onSetColor={handleSetColor} inventory={inventory} onSetInventory={handleSetInventory} />
+      <BOMPanel
+        entries={bom}
+        selectedPartIds={selectedPartIds}
+        parts={snapshot.parts}
+        onFlashPart={handleFlashPart}
+        onFlashDefinition={handleFlashDefinition}
+        onSetColor={handleSetColor}
+        inventory={inventory}
+        onSetInventory={handleSetInventory}
+      />
       {toast && <div className="toast">{toast}</div>}
     </div>
   );

--- a/configurator/src/components/BOMPanel.tsx
+++ b/configurator/src/components/BOMPanel.tsx
@@ -33,16 +33,28 @@ function exportCSV(entries: BOMEntry[], inventory: Record<string, number>) {
   URL.revokeObjectURL(url);
 }
 
-export function BOMPanel({ entries, selectedPartIds, parts, onFlashPart, onFlashDefinition, onSetColor, inventory, onSetInventory }: BOMPanelProps) {
+export function BOMPanel({
+  entries,
+  selectedPartIds,
+  parts,
+  onFlashPart,
+  onFlashDefinition,
+  onSetColor,
+  inventory,
+  onSetInventory,
+}: BOMPanelProps) {
   const totalParts = entries.reduce((sum, e) => sum + e.quantity, 0);
   const [showInventory, setShowInventory] = useState(false);
 
   const selectedParts = parts.filter((p) => selectedPartIds.has(p.instanceId));
 
   // If all selected parts share the same color, show it; otherwise null (mixed)
-  const currentColor = selectedParts.length > 0
-    ? (selectedParts.every((p) => p.color === selectedParts[0].color) ? (selectedParts[0].color ?? null) : null)
-    : null;
+  const currentColor =
+    selectedParts.length > 0
+      ? selectedParts.every((p) => p.color === selectedParts[0].color)
+        ? (selectedParts[0].color ?? null)
+        : null
+      : null;
 
   const totalNeed = showInventory
     ? entries.reduce((sum, e) => sum + Math.max(0, e.quantity - (inventory[e.definitionId] || 0)), 0)
@@ -72,11 +84,7 @@ export function BOMPanel({ entries, selectedPartIds, parts, onFlashPart, onFlash
             {selectedParts.map((p) => {
               const def = getPartDefinition(p.definitionId);
               return (
-                <li
-                  key={p.instanceId}
-                  className="selection-item"
-                  onClick={() => onFlashPart(p.instanceId)}
-                >
+                <li key={p.instanceId} className="selection-item" onClick={() => onFlashPart(p.instanceId)}>
                   {def?.name ?? p.definitionId}
                 </li>
               );
@@ -96,11 +104,7 @@ export function BOMPanel({ entries, selectedPartIds, parts, onFlashPart, onFlash
             >
               Inventory
             </button>
-            <button
-              className="bom-export-btn"
-              onClick={() => exportCSV(entries, inventory)}
-              title="Export as CSV"
-            >
+            <button className="bom-export-btn" onClick={() => exportCSV(entries, inventory)} title="Export as CSV">
               Export CSV
             </button>
           </div>
@@ -109,8 +113,7 @@ export function BOMPanel({ entries, selectedPartIds, parts, onFlashPart, onFlash
 
       {entries.length === 0 ? (
         <p className="bom-empty">
-          No parts placed yet. Select a part from the catalog and click on the
-          grid to place it.
+          No parts placed yet. Select a part from the catalog and click on the grid to place it.
         </p>
       ) : (
         <>
@@ -152,9 +155,7 @@ export function BOMPanel({ entries, selectedPartIds, parts, onFlashPart, onFlash
                       </td>
                     )}
                     {showInventory && (
-                      <td className={`bom-need${need > 0 ? " bom-need-remaining" : " bom-need-done"}`}>
-                        {need}
-                      </td>
+                      <td className={`bom-need${need > 0 ? " bom-need-remaining" : " bom-need-done"}`}>{need}</td>
                     )}
                     {showInventory && (
                       <td className={`bom-excess${excess > 0 ? " bom-excess-has" : ""}`}>
@@ -173,7 +174,6 @@ export function BOMPanel({ entries, selectedPartIds, parts, onFlashPart, onFlash
           </div>
         </>
       )}
-
     </div>
   );
 }

--- a/configurator/src/components/ColorPicker.tsx
+++ b/configurator/src/components/ColorPicker.tsx
@@ -24,10 +24,13 @@ interface ColorPickerProps {
 export function ColorPicker({ currentColor, onColorChange }: ColorPickerProps) {
   const [customHex, setCustomHex] = useState(currentColor ?? "");
 
-  const handleSwatchClick = useCallback((hex: string) => {
-    onColorChange(hex);
-    setCustomHex(hex);
-  }, [onColorChange]);
+  const handleSwatchClick = useCallback(
+    (hex: string) => {
+      onColorChange(hex);
+      setCustomHex(hex);
+    },
+    [onColorChange],
+  );
 
   const handleReset = useCallback(() => {
     onColorChange(undefined);
@@ -47,11 +50,7 @@ export function ColorPicker({ currentColor, onColorChange }: ColorPickerProps) {
     <div className="color-picker">
       <div className="color-picker-header">
         <span className="color-picker-label">Color</span>
-        <button
-          className="color-picker-reset"
-          onClick={handleReset}
-          title="Reset to default category color"
-        >
+        <button className="color-picker-reset" onClick={handleReset} title="Reset to default category color">
           Reset
         </button>
       </div>
@@ -67,16 +66,15 @@ export function ColorPicker({ currentColor, onColorChange }: ColorPickerProps) {
         ))}
       </div>
       <div className="color-custom-row">
-        <div
-          className="color-preview"
-          style={{ backgroundColor: currentColor ?? "#666" }}
-        />
+        <div className="color-preview" style={{ backgroundColor: currentColor ?? "#666" }} />
         <input
           className="color-hex-input"
           type="text"
           value={customHex}
           onChange={(e) => setCustomHex(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") handleCustomSubmit(); }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleCustomSubmit();
+          }}
           placeholder="#ff0000"
           maxLength={7}
         />

--- a/configurator/src/components/Sidebar.tsx
+++ b/configurator/src/components/Sidebar.tsx
@@ -1,7 +1,15 @@
 import { useState, useSyncExternalStore, useCallback } from "react";
 import { PART_CATALOG } from "../data/catalog";
 import { PART_COLORS } from "../constants";
-import { subscribeCustomParts, getCustomPartsSnapshot, importModelFile, deleteCustomPart, deleteUnusedCustomParts, downloadCustomPart, replaceCustomPart } from "../data/custom-parts";
+import {
+  subscribeCustomParts,
+  getCustomPartsSnapshot,
+  importModelFile,
+  deleteCustomPart,
+  deleteUnusedCustomParts,
+  downloadCustomPart,
+  replaceCustomPart,
+} from "../data/custom-parts";
 import { useThumbnail } from "../thumbnails/useThumbnail";
 import type { InteractionMode, PartCategory, PartDefinition } from "../types";
 
@@ -11,21 +19,50 @@ interface SidebarProps {
   usedDefinitionIds: Set<string>;
 }
 
-const SECTIONS: { key: string; label: string; filter: (p: PartDefinition) => boolean }[] = [
-  { key: "connector", label: "Connectors", filter: (p) => p.category === "connector" && !p.id.includes("-pt-") && !p.id.includes("-foot") },
-  { key: "connector-pt", label: "Pull-Through", filter: (p) => p.category === "connector" && p.id.includes("-pt-") },
-  { key: "support", label: "Supports", filter: (p) => p.category === "support" },
-  { key: "connector-foot", label: "Feet", filter: (p) => p.category === "connector" && p.id.includes("-foot") && !p.id.includes("-pt-") },
-  { key: "lockpin", label: "Lock Pins", filter: (p) => p.category === "lockpin" },
+const SECTIONS: {
+  key: string;
+  label: string;
+  filter: (p: PartDefinition) => boolean;
+}[] = [
+  {
+    key: "connector",
+    label: "Connectors",
+    filter: (p) => p.category === "connector" && !p.id.includes("-pt-") && !p.id.includes("-foot"),
+  },
+  {
+    key: "connector-pt",
+    label: "Pull-Through",
+    filter: (p) => p.category === "connector" && p.id.includes("-pt-"),
+  },
+  {
+    key: "support",
+    label: "Supports",
+    filter: (p) => p.category === "support",
+  },
+  {
+    key: "connector-foot",
+    label: "Feet",
+    filter: (p) => p.category === "connector" && p.id.includes("-foot") && !p.id.includes("-pt-"),
+  },
+  {
+    key: "lockpin",
+    label: "Lock Pins",
+    filter: (p) => p.category === "lockpin",
+  },
 ];
 
 function getCategoryIcon(category: PartCategory): string {
   switch (category) {
-    case "connector": return "+";
-    case "support": return "||";
-    case "other": return "3D";
-    case "custom": return "3D";
-    default: return ".";
+    case "connector":
+      return "+";
+    case "support":
+      return "||";
+    case "other":
+      return "3D";
+    case "custom":
+      return "3D";
+    default:
+      return ".";
   }
 }
 
@@ -33,11 +70,7 @@ function PartButton({ part, isActive, onSelect }: { part: PartDefinition; isActi
   const color = PART_COLORS[part.category] || PART_COLORS.custom;
   const thumbnail = useThumbnail(part);
   return (
-    <button
-      className={`catalog-item ${isActive ? "active" : ""}`}
-      onClick={onSelect}
-      title={part.description}
-    >
+    <button className={`catalog-item ${isActive ? "active" : ""}`} onClick={onSelect} title={part.description}>
       <div
         className="catalog-item-preview"
         style={{
@@ -59,8 +92,7 @@ function PartButton({ part, isActive, onSelect }: { part: PartDefinition; isActi
 }
 
 export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: SidebarProps) {
-  const activePlaceId =
-    activeMode.type === "place" ? activeMode.definitionId : null;
+  const activePlaceId = activeMode.type === "place" ? activeMode.definitionId : null;
 
   const [searchQuery, setSearchQuery] = useState("");
   const [collapsed, setCollapsed] = useState<Set<string>>(() => {
@@ -73,10 +105,7 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
   });
 
   // Subscribe to custom parts changes
-  const customSnapshot = useSyncExternalStore(
-    subscribeCustomParts,
-    getCustomPartsSnapshot,
-  );
+  const customSnapshot = useSyncExternalStore(subscribeCustomParts, getCustomPartsSnapshot);
 
   const handleImportModel = useCallback(() => {
     const input = document.createElement("input");
@@ -100,7 +129,9 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
       else next.add(key);
-      try { localStorage.setItem("homeracker-collapsed", JSON.stringify([...next])); } catch { }
+      try {
+        localStorage.setItem("homeracker-collapsed", JSON.stringify([...next]));
+      } catch {}
       return next;
     });
   }, []);
@@ -115,12 +146,28 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
       <div className="sidebar-header">
         <h1>HomeRacker Configurator</h1>
         <div className="sidebar-subtitle sidebar-links">
-          <a href="https://github.com/kellerlabs/homeracker-community/tree/main/configurator" target="_blank" rel="noopener noreferrer" title="Configurator GitHub">
-            Configurator <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" /></svg>
+          <a
+            href="https://github.com/kellerlabs/homeracker-community/tree/main/configurator"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Configurator GitHub"
+          >
+            Configurator{" "}
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+            </svg>
           </a>
 
-          <a href="https://github.com/kellerlabs/homeracker" target="_blank" rel="noopener noreferrer" title="HomeRacker Core GitHub">
-            HomeRacker <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" /></svg>
+          <a
+            href="https://github.com/kellerlabs/homeracker"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="HomeRacker Core GitHub"
+          >
+            HomeRacker{" "}
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+            </svg>
           </a>
         </div>
       </div>
@@ -132,7 +179,9 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
           placeholder="Filter parts..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Escape") setSearchQuery(""); }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setSearchQuery("");
+          }}
         />
       </div>
 
@@ -144,10 +193,7 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
 
         return (
           <div key={key} className="catalog-section">
-            <h2
-              className="catalog-section-title"
-              onClick={() => toggleCategory(key)}
-            >
+            <h2 className="catalog-section-title" onClick={() => toggleCategory(key)}>
               <span className="catalog-section-toggle">{isCollapsed ? "\u25b8" : "\u25be"}</span>
               {label}
               <span className="catalog-section-count">{parts.length}</span>
@@ -190,10 +236,7 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
 
         return (
           <div className="catalog-section">
-            <h2
-              className="catalog-section-title"
-              onClick={() => toggleCategory("other")}
-            >
+            <h2 className="catalog-section-title" onClick={() => toggleCategory("other")}>
               <span className="catalog-section-toggle">{isOtherCollapsed ? "\u25b8" : "\u25be"}</span>
               Other
               <span className="catalog-section-count">{otherParts.length}</span>
@@ -217,10 +260,7 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
                   const isGroupCollapsed = !isSearching && collapsed.has(groupKey);
                   return (
                     <div key={groupKey} className="catalog-subgroup">
-                      <h3
-                        className="catalog-subgroup-title"
-                        onClick={() => toggleCategory(groupKey)}
-                      >
+                      <h3 className="catalog-subgroup-title" onClick={() => toggleCategory(groupKey)}>
                         <span className="catalog-section-toggle">{isGroupCollapsed ? "\u25b8" : "\u25be"}</span>
                         {groupName}
                         <span className="catalog-section-count">{parts.length}</span>
@@ -254,15 +294,10 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
 
         return (
           <div className="catalog-section">
-            <h2
-              className="catalog-section-title"
-              onClick={() => toggleCategory("custom")}
-            >
+            <h2 className="catalog-section-title" onClick={() => toggleCategory("custom")}>
               <span className="catalog-section-toggle">{isCustomCollapsed ? "\u25b8" : "\u25be"}</span>
               Custom
-              {customParts.length > 0 && (
-                <span className="catalog-section-count">{customParts.length}</span>
-              )}
+              {customParts.length > 0 && <span className="catalog-section-count">{customParts.length}</span>}
             </h2>
             {!isCustomCollapsed && (
               <>
@@ -296,8 +331,11 @@ export function Sidebar({ onSelectPart, activeMode, usedDefinitionIds }: Sidebar
                             input.onchange = async () => {
                               const file = input.files?.[0];
                               if (file) {
-                                try { await replaceCustomPart(part.id, file); }
-                                catch (err) { console.error("Replace failed:", err); }
+                                try {
+                                  await replaceCustomPart(part.id, file);
+                                } catch (err) {
+                                  console.error("Replace failed:", err);
+                                }
                               }
                             };
                             input.click();

--- a/configurator/src/components/Toolbar.tsx
+++ b/configurator/src/components/Toolbar.tsx
@@ -43,30 +43,18 @@ export function Toolbar({
         <button className="toolbar-btn" onClick={onUndo} title="Undo (Ctrl+Z)">
           Undo
         </button>
-        <button
-          className="toolbar-btn"
-          onClick={onRedo}
-          title="Redo (Ctrl+Shift+Z)"
-        >
+        <button className="toolbar-btn" onClick={onRedo} title="Redo (Ctrl+Shift+Z)">
           Redo
         </button>
       </div>
 
       <div className="toolbar-group">
         {onDelete && (
-          <button
-            className="toolbar-btn toolbar-btn-danger"
-            onClick={onDelete}
-            title="Delete selected (Del)"
-          >
+          <button className="toolbar-btn toolbar-btn-danger" onClick={onDelete} title="Delete selected (Del)">
             Delete{selectedCount > 1 ? ` (${selectedCount})` : ""}
           </button>
         )}
-        <button
-          className="toolbar-btn toolbar-btn-danger"
-          onClick={onClear}
-          title="Clear all parts"
-        >
+        <button className="toolbar-btn toolbar-btn-danger" onClick={onClear} title="Clear all parts">
           Clear All
         </button>
       </div>
@@ -111,9 +99,7 @@ export function Toolbar({
 
       {mode.type === "place" && (
         <div className="toolbar-group">
-          <span className="toolbar-mode-label">
-            Placing: {mode.definitionId}
-          </span>
+          <span className="toolbar-mode-label">Placing: {mode.definitionId}</span>
           <button className="toolbar-btn" onClick={onEscape}>
             Cancel (Esc)
           </button>
@@ -122,9 +108,7 @@ export function Toolbar({
 
       {mode.type === "paste" && (
         <div className="toolbar-group">
-          <span className="toolbar-mode-label">
-            Pasting {mode.clipboard.parts.length} part(s)
-          </span>
+          <span className="toolbar-mode-label">Pasting {mode.clipboard.parts.length} part(s)</span>
           <button className="toolbar-btn" onClick={onEscape}>
             Cancel (Esc)
           </button>

--- a/configurator/src/components/ViewportCanvas.tsx
+++ b/configurator/src/components/ViewportCanvas.tsx
@@ -1,5 +1,13 @@
 import { Canvas, useThree, useFrame } from "@react-three/fiber";
-import { OrbitControls, Grid, GizmoHelper, GizmoViewport, OrthographicCamera, PerspectiveCamera, useGLTF } from "@react-three/drei";
+import {
+  OrbitControls,
+  Grid,
+  GizmoHelper,
+  GizmoViewport,
+  OrthographicCamera,
+  PerspectiveCamera,
+  useGLTF,
+} from "@react-three/drei";
 import { useCallback, useRef, useState, useEffect, useMemo, Suspense, useLayoutEffect } from "react";
 import * as THREE from "three";
 import { BASE_UNIT, PART_COLORS, GRID_EXTENT } from "../constants";
@@ -94,9 +102,20 @@ type CameraSwitchSnapshot = {
 function OrthoIcon() {
   return (
     <svg viewBox="641.712 107.069 51.822 62.187" aria-hidden="true" focusable="false">
-      <path fill="currentColor" d="M 667.623 139.077 L 641.712 123.073 L 667.623 107.069 L 693.534 123.073 L 667.623 139.077 Z" />
-      <path fill="currentColor" d="M 667.623 169.256 L 667.623 139.077 L 693.534 123.073 L 693.534 153.252 L 667.623 169.256 Z" opacity="0.25" />
-      <path fill="currentColor" d="M 667.623 169.256 L 641.712 153.252 L 641.712 123.073 L 667.623 139.077 L 667.623 169.256 Z" opacity="0.5" />
+      <path
+        fill="currentColor"
+        d="M 667.623 139.077 L 641.712 123.073 L 667.623 107.069 L 693.534 123.073 L 667.623 139.077 Z"
+      />
+      <path
+        fill="currentColor"
+        d="M 667.623 169.256 L 667.623 139.077 L 693.534 123.073 L 693.534 153.252 L 667.623 169.256 Z"
+        opacity="0.25"
+      />
+      <path
+        fill="currentColor"
+        d="M 667.623 169.256 L 641.712 153.252 L 641.712 123.073 L 667.623 139.077 L 667.623 169.256 Z"
+        opacity="0.5"
+      />
     </svg>
   );
 }
@@ -104,9 +123,20 @@ function OrthoIcon() {
 function PerspIcon() {
   return (
     <svg viewBox="573.563 112.631 54.108 49.236" aria-hidden="true" focusable="false">
-      <path fill="currentColor" d="M 600.616 130.34 L 573.563 120.122 L 600.329 112.631 L 627.671 120.122 L 600.616 130.34 Z" />
-      <path fill="currentColor" d="M 600.688 161.817 L 600.616 130.308 L 627.671 119.984 L 627.671 151.494 L 600.688 161.817 Z" opacity="0.25" />
-      <path fill="currentColor" d="M 600.677 161.867 L 573.623 151.692 L 573.623 120.182 L 600.677 130.357 L 600.677 161.867 Z" opacity="0.5" />
+      <path
+        fill="currentColor"
+        d="M 600.616 130.34 L 573.563 120.122 L 600.329 112.631 L 627.671 120.122 L 600.616 130.34 Z"
+      />
+      <path
+        fill="currentColor"
+        d="M 600.688 161.817 L 600.616 130.308 L 627.671 119.984 L 627.671 151.494 L 600.688 161.817 Z"
+        opacity="0.25"
+      />
+      <path
+        fill="currentColor"
+        d="M 600.677 161.867 L 573.623 151.692 L 573.623 120.182 L 600.677 130.357 L 600.677 161.867 Z"
+        opacity="0.5"
+      />
     </svg>
   );
 }
@@ -999,9 +1029,7 @@ function ApplyCameraSwitchSnapshot({
 
     if (camera instanceof THREE.OrthographicCamera) {
       const fov = snapshot.fov ?? 50;
-      const frustumHeight =
-        snapshot.frustumHeight ??
-        (2 * Math.max(distance, 1) * Math.tan((fov * Math.PI) / 360));
+      const frustumHeight = snapshot.frustumHeight ?? 2 * Math.max(distance, 1) * Math.tan((fov * Math.PI) / 360);
       camera.top = frustumHeight / 2;
       camera.bottom = -frustumHeight / 2;
       camera.right = (frustumHeight * aspect) / 2;
@@ -1010,11 +1038,9 @@ function ApplyCameraSwitchSnapshot({
       camera.updateProjectionMatrix();
     } else if (camera instanceof THREE.PerspectiveCamera) {
       const frustumHeight = snapshot.frustumHeight;
-      const fov = snapshot.fov ?? (
-        frustumHeight
-          ? THREE.MathUtils.radToDeg(2 * Math.atan(frustumHeight / (2 * Math.max(distance, 1))))
-          : 50
-      );
+      const fov =
+        snapshot.fov ??
+        (frustumHeight ? THREE.MathUtils.radToDeg(2 * Math.atan(frustumHeight / (2 * Math.max(distance, 1)))) : 50);
       camera.fov = THREE.MathUtils.clamp(fov, 10, 120);
       camera.updateProjectionMatrix();
     }
@@ -1087,7 +1113,7 @@ function FitCamera({ parts }: { parts: PlacedPart[] }) {
       const frustumHeight = Math.max(
         (dy || BASE_UNIT) * padding,
         ((dx || BASE_UNIT) * padding) / aspect,
-        ((dz || BASE_UNIT) * padding) / aspect
+        ((dz || BASE_UNIT) * padding) / aspect,
       );
       camera.top = frustumHeight / 2;
       camera.bottom = -frustumHeight / 2;
@@ -1095,7 +1121,7 @@ function FitCamera({ parts }: { parts: PlacedPart[] }) {
       camera.left = -(frustumHeight * aspect) / 2;
     } else if (camera instanceof THREE.PerspectiveCamera) {
       const fov = camera.fov ?? 50;
-      const perspectiveDist = Math.max(radius / Math.tan((fov / 2) * Math.PI / 180), 100);
+      const perspectiveDist = Math.max(radius / Math.tan(((fov / 2) * Math.PI) / 180), 100);
       camera.position.set(cx + perspectiveDist * 0.6, cy + perspectiveDist * 0.7, cz + perspectiveDist * 0.6);
       camera.lookAt(cx, cy, cz);
     }
@@ -1781,10 +1807,7 @@ export function ViewportCanvas(props: ViewportProps) {
       data-placing={props.mode.type === "place" ? props.mode.definitionId : undefined}
       onPointerDown={handleViewportPointerDown}
     >
-      <Canvas
-        gl={{ antialias: true }}
-        scene={{ background: new THREE.Color("#3d3d5c") }}
-      >
+      <Canvas gl={{ antialias: true }} scene={{ background: new THREE.Color("#3d3d5c") }}>
         {isOrthographic ? (
           <OrthographicCamera makeDefault position={[150, 200, 150]} near={-20000} far={20000} zoom={1} />
         ) : (
@@ -1811,12 +1834,8 @@ export function ViewportCanvas(props: ViewportProps) {
         onClick={handleToggleCameraMode}
         title="Toggle perspective/orthographic camera"
       >
-        <span className="viewport-camera-toggle__thumb">
-          {isOrthographic ? <OrthoIcon /> : <PerspIcon />}
-        </span>
-        <span className="viewport-camera-toggle__label">
-          {isOrthographic ? "ORTHO" : "PERSP"}
-        </span>
+        <span className="viewport-camera-toggle__thumb">{isOrthographic ? <OrthoIcon /> : <PerspIcon />}</span>
+        <span className="viewport-camera-toggle__label">{isOrthographic ? "ORTHO" : "PERSP"}</span>
       </button>
       {boxSelectRect && (
         <div

--- a/configurator/src/components/ViewportCanvas.tsx
+++ b/configurator/src/components/ViewportCanvas.tsx
@@ -3,12 +3,27 @@ import { OrbitControls, Grid, GizmoHelper, GizmoViewport, useGLTF } from "@react
 import { useCallback, useRef, useState, useEffect, useMemo, Suspense } from "react";
 import * as THREE from "three";
 import { BASE_UNIT, PART_COLORS, GRID_EXTENT } from "../constants";
-import type { PlacedPart, InteractionMode, GridPosition, Rotation3, RotationStep, Axis, DragState, ClipboardData } from "../types";
+import type {
+  PlacedPart,
+  InteractionMode,
+  GridPosition,
+  Rotation3,
+  RotationStep,
+  Axis,
+  DragState,
+  ClipboardData,
+} from "../types";
 import { getPartDefinition } from "../data/catalog";
 import { isCustomPart, getCustomPartGeometry } from "../data/custom-parts";
 import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import { AssemblyState } from "../assembly/AssemblyState";
-import { nextOrientation, orientationToRotation, transformCell, rotateGridCells, computeGroundLift } from "../assembly/grid-utils";
+import {
+  nextOrientation,
+  orientationToRotation,
+  transformCell,
+  rotateGridCells,
+  computeGroundLift,
+} from "../assembly/grid-utils";
 import { findBestSnap, findBestConnectorSnap, type GridRay } from "../assembly/snap";
 import { detectCollidingPartIds, detectCollidingPartIdsMesh } from "../assembly/collision";
 import { registerPartGeometry, hasRegisteredGeometry } from "../assembly/geometry-registry";
@@ -20,11 +35,16 @@ import { registerPartGeometry, hasRegisteredGeometry } from "../assembly/geometr
 function makeColorMaterial(
   color: string,
   original?: THREE.Material | null,
-  overrides?: { transparent?: boolean; opacity?: number; emissive?: THREE.Color; emissiveIntensity?: number },
+  overrides?: {
+    transparent?: boolean;
+    opacity?: number;
+    emissive?: THREE.Color;
+    emissiveIntensity?: number;
+  },
 ): THREE.MeshStandardMaterial {
   const src = original instanceof THREE.MeshStandardMaterial ? original : null;
   return new THREE.MeshStandardMaterial({
-    ...src as THREE.MeshStandardMaterialParameters,
+    ...(src as THREE.MeshStandardMaterialParameters),
     color: new THREE.Color(color),
     vertexColors: false,
     ...overrides,
@@ -36,7 +56,12 @@ interface ViewportProps {
   mode: InteractionMode;
   selectedPartIds: Set<string>;
   assembly: AssemblyState;
-  onPlacePart: (definitionId: string, position: GridPosition, rotation: PlacedPart["rotation"], orientation?: Axis) => void;
+  onPlacePart: (
+    definitionId: string,
+    position: GridPosition,
+    rotation: PlacedPart["rotation"],
+    orientation?: Axis,
+  ) => void;
   onMovePart: (instanceId: string, newPosition: GridPosition, rotation?: Rotation3, orientation?: Axis) => void;
   onMoveSelectedParts: (primaryId: string, newPosition: GridPosition, rotation?: Rotation3, orientation?: Axis) => void;
   onClickPart: (instanceId: string, shiftKey: boolean) => void;
@@ -90,11 +115,7 @@ function modelCenterOffset(def: { gridCells: GridPosition[] }, orientation: Axis
   const maxX = Math.max(...cells.map((c) => c[0]));
   const maxY = Math.max(...cells.map((c) => c[1]));
   const maxZ = Math.max(...cells.map((c) => c[2]));
-  return [
-    ((minX + maxX) / 2) * BASE_UNIT,
-    ((minY + maxY) / 2) * BASE_UNIT,
-    ((minZ + maxZ) / 2) * BASE_UNIT,
-  ];
+  return [((minX + maxX) / 2) * BASE_UNIT, ((minY + maxY) / 2) * BASE_UNIT, ((minZ + maxZ) / 2) * BASE_UNIT];
 }
 
 /** A placed part rendered with its actual GLB model (or custom STL geometry) */
@@ -119,12 +140,30 @@ function PartMesh({
   if (!def) return null;
 
   if (isCustomPart(part.definitionId)) {
-    return <CustomPartMesh part={part} isSelected={isSelected} isDragging={isDragging} isPlacing={isPlacing} isFlashing={isFlashing} isColliding={isColliding} onPointerDown={onPointerDown} />;
+    return (
+      <CustomPartMesh
+        part={part}
+        isSelected={isSelected}
+        isDragging={isDragging}
+        isPlacing={isPlacing}
+        isFlashing={isFlashing}
+        isColliding={isColliding}
+        onPointerDown={onPointerDown}
+      />
+    );
   }
 
   return (
-    <Suspense fallback={<PartMeshFallback part={part} isSelected={isSelected} onClick={() => { }} />}>
-      <PartMeshLoaded part={part} isSelected={isSelected} isDragging={isDragging} isPlacing={isPlacing} isFlashing={isFlashing} isColliding={isColliding} onPointerDown={onPointerDown} />
+    <Suspense fallback={<PartMeshFallback part={part} isSelected={isSelected} onClick={() => {}} />}>
+      <PartMeshLoaded
+        part={part}
+        isSelected={isSelected}
+        isDragging={isDragging}
+        isPlacing={isPlacing}
+        isFlashing={isFlashing}
+        isColliding={isColliding}
+        onPointerDown={onPointerDown}
+      />
     </Suspense>
   );
 }
@@ -186,12 +225,21 @@ function CustomPartMesh({
         if (!isPlacing) e.stopPropagation();
         onPointerDown(e);
       }}
-      onClick={(e) => { if (!isPlacing) e.stopPropagation(); }}
+      onClick={(e) => {
+        if (!isPlacing) e.stopPropagation();
+      }}
     >
       <group position={offset}>
         <group rotation={partEuler}>
           <mesh geometry={geometry}>
-            <meshStandardMaterial ref={flashRef} color={color} roughness={1} metalness={0} transparent={isDragging} opacity={opacity} />
+            <meshStandardMaterial
+              ref={flashRef}
+              color={color}
+              roughness={1}
+              metalness={0}
+              transparent={isDragging}
+              opacity={opacity}
+            />
           </mesh>
         </group>
       </group>
@@ -259,7 +307,10 @@ function PartMeshLoaded({
         const orig = originalMaterials.current.get(child) ?? child.material;
         if (isDragging) {
           if (part.color) {
-            child.material = makeColorMaterial(part.color, orig, { transparent: true, opacity: 0.3 });
+            child.material = makeColorMaterial(part.color, orig, {
+              transparent: true,
+              opacity: 0.3,
+            });
           } else {
             const mat = orig.clone();
             mat.transparent = true;
@@ -347,27 +398,21 @@ function PartMeshLoaded({
         if (!isPlacing) e.stopPropagation();
         onPointerDown(e);
       }}
-      onClick={(e) => { if (!isPlacing) e.stopPropagation(); }}
+      onClick={(e) => {
+        if (!isPlacing) e.stopPropagation();
+      }}
     >
       <group position={offset}>
         <group rotation={partEuler}>
           <group rotation={orientEuler}>
-            <primitive
-              ref={groupRef}
-              object={cloned}
-            />
+            <primitive ref={groupRef} object={cloned} />
           </group>
         </group>
       </group>
       {isSelected && !isDragging && (
         <mesh position={offset}>
           <boxGeometry args={[BASE_UNIT * 1.1, BASE_UNIT * 1.1, BASE_UNIT * 1.1]} />
-          <meshBasicMaterial
-            color={PART_COLORS.selected}
-            wireframe
-            transparent
-            opacity={0.3}
-          />
+          <meshBasicMaterial color={PART_COLORS.selected} wireframe transparent opacity={0.3} />
         </mesh>
       )}
     </group>
@@ -388,9 +433,7 @@ function PartMeshFallback({
   if (!def) return null;
 
   const worldPos = gridToWorld(part.position);
-  const color = isSelected
-    ? PART_COLORS.selected
-    : (part.color || PART_COLORS[def.category] || "#888888");
+  const color = isSelected ? PART_COLORS.selected : part.color || PART_COLORS[def.category] || "#888888";
 
   // Use oriented + rotated cells for correct sizing and offset
   const orient = part.orientation ?? "y";
@@ -428,11 +471,7 @@ function PartMeshFallback({
 
 /** Convert a Rotation3 (degrees) to a radians Euler tuple for Three.js */
 function degreesToEuler(rot: Rotation3): [number, number, number] {
-  return [
-    (rot[0] * Math.PI) / 180,
-    (rot[1] * Math.PI) / 180,
-    (rot[2] * Math.PI) / 180,
-  ];
+  return [(rot[0] * Math.PI) / 180, (rot[1] * Math.PI) / 180, (rot[2] * Math.PI) / 180];
 }
 
 /** Cycle a single rotation step: 0 -> 90 -> 180 -> 270 -> 0 */
@@ -457,7 +496,9 @@ function GhostModel({
     return <CustomGhostModel definitionId={definitionId} rotation={rotation} isSnapped={isSnapped} />;
   }
 
-  return <GLBGhostModel definitionId={definitionId} rotation={rotation} orientation={orientation} isSnapped={isSnapped} />;
+  return (
+    <GLBGhostModel definitionId={definitionId} rotation={rotation} orientation={orientation} isSnapped={isSnapped} />
+  );
 }
 
 /** Ghost preview for GLB-based parts */
@@ -504,10 +545,7 @@ function GLBGhostModel({
     <group position={offset}>
       <group rotation={euler}>
         <group rotation={orientEuler}>
-          <primitive
-            ref={groupRef}
-            object={cloned}
-          />
+          <primitive ref={groupRef} object={cloned} />
         </group>
       </group>
     </group>
@@ -570,12 +608,7 @@ function GhostFallback({ definitionId, orientation }: { definitionId: string; or
   return (
     <mesh position={offset}>
       <boxGeometry args={[sizeX * 0.95, sizeY * 0.95, sizeZ * 0.95]} />
-      <meshStandardMaterial
-        color={PART_COLORS.ghost_valid}
-        transparent
-        opacity={0.4}
-        depthWrite={false}
-      />
+      <meshStandardMaterial color={PART_COLORS.ghost_valid} transparent opacity={0.4} depthWrite={false} />
     </mesh>
   );
 }
@@ -624,7 +657,12 @@ function useGhostSnap({
   planeY?: number;
   initialPosition?: GridPosition;
   grabOffsetRef?: React.MutableRefObject<[number, number] | null>;
-  syncRef?: React.MutableRefObject<{ position: GridPosition; orientation: Axis; rotation: Rotation3; isSnapped: boolean }>;
+  syncRef?: React.MutableRefObject<{
+    position: GridPosition;
+    orientation: Axis;
+    rotation: Rotation3;
+    isSnapped: boolean;
+  }>;
 }) {
   const { camera, raycaster, pointer } = useThree();
   const [gridPos, setGridPos] = useState<GridPosition>(initialPosition ?? [0, 0, 0]);
@@ -648,10 +686,7 @@ function useGhostSnap({
     if (grabOffsetRef) {
       if (grabOffsetRef.current === null && initialPosition) {
         const partWorldPos = gridToWorld(initialPosition);
-        grabOffsetRef.current = [
-          intersectPoint.x - partWorldPos[0],
-          intersectPoint.z - partWorldPos[2],
-        ];
+        grabOffsetRef.current = [intersectPoint.x - partWorldPos[0], intersectPoint.z - partWorldPos[2]];
       }
       if (grabOffsetRef.current) {
         intersectPoint.x -= grabOffsetRef.current[0];
@@ -668,11 +703,7 @@ function useGhostSnap({
         raycaster.ray.origin.y / BASE_UNIT,
         raycaster.ray.origin.z / BASE_UNIT,
       ],
-      direction: [
-        raycaster.ray.direction.x,
-        raycaster.ray.direction.y,
-        raycaster.ray.direction.z,
-      ],
+      direction: [raycaster.ray.direction.x, raycaster.ray.direction.y, raycaster.ray.direction.z],
     };
 
     // Snap position is the anchor part's absolute position (cursor + offset)
@@ -680,9 +711,9 @@ function useGhostSnap({
 
     // Try snapping: supports snap to connector sockets, connectors snap to support endpoints
     const snap = snapEnabled
-      ? (isSupport
+      ? isSupport
         ? findBestSnap(assembly, definitionId, snapPos, 3, gridRay)
-        : findBestConnectorSnap(assembly, definitionId, snapPos, 3, gridRay, ghostRotation))
+        : findBestConnectorSnap(assembly, definitionId, snapPos, 3, gridRay, ghostRotation)
       : null;
 
     if (snap) {
@@ -705,7 +736,13 @@ function useGhostSnap({
       setEffectiveOrientation(orient);
       setEffectiveRotation(snapRotation);
       setIsSnapped(true);
-      if (syncRef) syncRef.current = { position: resultPos, orientation: orient, rotation: snapRotation, isSnapped: true };
+      if (syncRef)
+        syncRef.current = {
+          position: resultPos,
+          orientation: orient,
+          rotation: snapRotation,
+          isSnapped: true,
+        };
       return;
     }
 
@@ -718,7 +755,13 @@ function useGhostSnap({
     setEffectiveRotation(ghostRotation);
     setGridPos(cursorGrid);
     setIsSnapped(false);
-    if (syncRef) syncRef.current = { position: cursorGrid, orientation: orient, rotation: ghostRotation, isSnapped: false };
+    if (syncRef)
+      syncRef.current = {
+        position: cursorGrid,
+        orientation: orient,
+        rotation: ghostRotation,
+        isSnapped: false,
+      };
   });
 
   return { gridPos, effectiveOrientation, effectiveRotation, isSnapped, def };
@@ -745,7 +788,12 @@ function GhostPreview({
   onPlacePart: (definitionId: string, position: GridPosition, rotation: Rotation3, orientation: Axis) => void;
 }) {
   const { gridPos, effectiveOrientation, effectiveRotation, isSnapped, def } = useGhostSnap({
-    definitionId, assembly, ghostOrientation, ghostRotation, yLift, snapEnabled,
+    definitionId,
+    assembly,
+    ghostOrientation,
+    ghostRotation,
+    yLift,
+    snapEnabled,
     syncRef: ghostStateRef,
   });
 
@@ -772,7 +820,12 @@ function GhostPreview({
   return (
     <group name="ghost-preview" position={worldPos} onClick={handleGhostClick}>
       <Suspense fallback={<GhostFallback definitionId={definitionId} orientation={effectiveOrientation} />}>
-        <GhostModel definitionId={definitionId} rotation={effectiveRotation} orientation={effectiveOrientation} isSnapped={isSnapped} />
+        <GhostModel
+          definitionId={definitionId}
+          rotation={effectiveRotation}
+          orientation={effectiveOrientation}
+          isSnapped={isSnapped}
+        />
       </Suspense>
     </group>
   );
@@ -790,7 +843,11 @@ function DragPreview({
 }: {
   dragState: DragState;
   assembly: AssemblyState;
-  dropTargetRef: React.MutableRefObject<{ position: GridPosition; orientation?: Axis; rotation?: Rotation3 }>;
+  dropTargetRef: React.MutableRefObject<{
+    position: GridPosition;
+    orientation?: Axis;
+    rotation?: Rotation3;
+  }>;
   yLift: number;
   snapEnabled: boolean;
   selectedPartIds: Set<string>;
@@ -813,7 +870,11 @@ function DragPreview({
 
   // Keep dropTargetRef in sync
   useEffect(() => {
-    dropTargetRef.current = { position: gridPos, orientation: effectiveOrientation, rotation: dragState.rotation };
+    dropTargetRef.current = {
+      position: gridPos,
+      orientation: effectiveOrientation,
+      rotation: dragState.rotation,
+    };
   }, [gridPos, effectiveOrientation, dragState.rotation]);
 
   if (!def) return null;
@@ -832,20 +893,37 @@ function DragPreview({
     <group>
       <group name="drag-preview" position={worldPos}>
         <Suspense fallback={<GhostFallback definitionId={dragState.definitionId} orientation={effectiveOrientation} />}>
-          <GhostModel definitionId={dragState.definitionId} rotation={dragState.rotation} orientation={effectiveOrientation} isSnapped={isSnapped} />
+          <GhostModel
+            definitionId={dragState.definitionId}
+            rotation={dragState.rotation}
+            orientation={effectiveOrientation}
+            isSnapped={isSnapped}
+          />
         </Suspense>
       </group>
-      {isMultiDrag && parts.filter((p) => selectedPartIds.has(p.instanceId) && p.instanceId !== dragState.instanceId).map((p) => {
-        const offsetPos: GridPosition = [p.position[0] + delta[0], p.position[1] + delta[1], p.position[2] + delta[2]];
-        const wp = gridToWorld(offsetPos);
-        return (
-          <group key={p.instanceId} name={`drag-preview-${p.instanceId}`} position={wp}>
-            <Suspense fallback={<GhostFallback definitionId={p.definitionId} orientation={p.orientation ?? "y"} />}>
-              <GhostModel definitionId={p.definitionId} rotation={p.rotation} orientation={p.orientation ?? "y"} isSnapped={isSnapped} />
-            </Suspense>
-          </group>
-        );
-      })}
+      {isMultiDrag &&
+        parts
+          .filter((p) => selectedPartIds.has(p.instanceId) && p.instanceId !== dragState.instanceId)
+          .map((p) => {
+            const offsetPos: GridPosition = [
+              p.position[0] + delta[0],
+              p.position[1] + delta[1],
+              p.position[2] + delta[2],
+            ];
+            const wp = gridToWorld(offsetPos);
+            return (
+              <group key={p.instanceId} name={`drag-preview-${p.instanceId}`} position={wp}>
+                <Suspense fallback={<GhostFallback definitionId={p.definitionId} orientation={p.orientation ?? "y"} />}>
+                  <GhostModel
+                    definitionId={p.definitionId}
+                    rotation={p.rotation}
+                    orientation={p.orientation ?? "y"}
+                    isSnapped={isSnapped}
+                  />
+                </Suspense>
+              </group>
+            );
+          })}
     </group>
   );
 }
@@ -875,8 +953,12 @@ function FitCamera({ parts }: { parts: PlacedPart[] }) {
     fitted.current = true;
 
     // Compute bounding box of all part world positions
-    let minX = Infinity, minY = Infinity, minZ = Infinity;
-    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    let minX = Infinity,
+      minY = Infinity,
+      minZ = Infinity;
+    let maxX = -Infinity,
+      maxY = -Infinity,
+      maxZ = -Infinity;
     for (const part of parts) {
       const def = getPartDefinition(part.definitionId);
       if (!def) continue;
@@ -887,9 +969,12 @@ function FitCamera({ parts }: { parts: PlacedPart[] }) {
         const wx = (part.position[0] + cell[0]) * BASE_UNIT;
         const wy = (part.position[1] + cell[1]) * BASE_UNIT + BASE_UNIT / 2;
         const wz = (part.position[2] + cell[2]) * BASE_UNIT;
-        minX = Math.min(minX, wx); maxX = Math.max(maxX, wx + BASE_UNIT);
-        minY = Math.min(minY, wy); maxY = Math.max(maxY, wy + BASE_UNIT);
-        minZ = Math.min(minZ, wz); maxZ = Math.max(maxZ, wz + BASE_UNIT);
+        minX = Math.min(minX, wx);
+        maxX = Math.max(maxX, wx + BASE_UNIT);
+        minY = Math.min(minY, wy);
+        maxY = Math.max(maxY, wy + BASE_UNIT);
+        minZ = Math.min(minZ, wz);
+        maxZ = Math.max(maxZ, wz + BASE_UNIT);
       }
     }
 
@@ -903,7 +988,7 @@ function FitCamera({ parts }: { parts: PlacedPart[] }) {
 
     // Position camera so the bounding sphere fits in view
     const fov = (camera as THREE.PerspectiveCamera).fov ?? 50;
-    const dist = Math.max(radius / Math.tan((fov / 2) * Math.PI / 180), 100);
+    const dist = Math.max(radius / Math.tan(((fov / 2) * Math.PI) / 180), 100);
 
     camera.position.set(cx + dist * 0.6, cy + dist * 0.7, cz + dist * 0.6);
     camera.lookAt(cx, cy, cz);
@@ -967,17 +1052,18 @@ function PasteGhostPreview({
   return (
     <group name="paste-preview" onClick={handlePasteClick}>
       {clipboard.parts.map((cp, i) => {
-        const pos: GridPosition = [
-          gridPos[0] + cp.offset[0],
-          gridPos[1] + cp.offset[1],
-          gridPos[2] + cp.offset[2],
-        ];
+        const pos: GridPosition = [gridPos[0] + cp.offset[0], gridPos[1] + cp.offset[1], gridPos[2] + cp.offset[2]];
         const worldPos = gridToWorld(pos);
         const rot = addRotations(cp.rotation, ghostRotation);
         return (
           <group key={i} position={worldPos}>
             <Suspense fallback={<GhostFallback definitionId={cp.definitionId} orientation={cp.orientation} />}>
-              <GhostModel definitionId={cp.definitionId} rotation={rot} orientation={cp.orientation} isSnapped={isSnapped} />
+              <GhostModel
+                definitionId={cp.definitionId}
+                rotation={rot}
+                orientation={cp.orientation}
+                isSnapped={isSnapped}
+              />
             </Suspense>
           </group>
         );
@@ -992,7 +1078,11 @@ interface SceneProps extends ViewportProps {
   ghostStateRef: React.MutableRefObject<GhostState>;
   pasteStateRef: React.MutableRefObject<PasteGhostState>;
   dragState: DragState | null;
-  dropTargetRef: React.MutableRefObject<{ position: GridPosition; orientation?: Axis; rotation?: Rotation3 }>;
+  dropTargetRef: React.MutableRefObject<{
+    position: GridPosition;
+    orientation?: Axis;
+    rotation?: Rotation3;
+  }>;
   onPartPointerDown: (instanceId: string, nativeEvent: PointerEvent) => void;
   yLift: number;
   boxSelectActive: boolean;
@@ -1041,7 +1131,7 @@ function Scene({
         onClickEmpty();
       }
     },
-    [mode, onPlacePart, onPasteParts, onClickEmpty, ghostStateRef, pasteStateRef, dragState, ghostRotation]
+    [mode, onPlacePart, onPasteParts, onClickEmpty, ghostStateRef, pasteStateRef, dragState, ghostRotation],
   );
 
   return (
@@ -1168,7 +1258,11 @@ export function ViewportCanvas(props: ViewportProps) {
 
   // Drag state
   const [dragState, setDragState] = useState<DragState | null>(null);
-  const dropTargetRef = useRef<{ position: GridPosition; orientation?: Axis; rotation?: Rotation3 }>({
+  const dropTargetRef = useRef<{
+    position: GridPosition;
+    orientation?: Axis;
+    rotation?: Rotation3;
+  }>({
     position: [0, 0, 0],
   });
   const pendingDragRef = useRef<{
@@ -1209,7 +1303,10 @@ export function ViewportCanvas(props: ViewportProps) {
   // Box-select (marquee) state
   const boxSelectRef = useRef<{ startX: number; startY: number } | null>(null);
   const [boxSelectRect, setBoxSelectRect] = useState<{
-    x1: number; y1: number; x2: number; y2: number;
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
   } | null>(null);
 
   // Determine if we're placing a support (orientation cycling) vs connector (rotation)
@@ -1245,7 +1342,7 @@ export function ViewportCanvas(props: ViewportProps) {
         startY: nativeEvent.clientY,
       };
     },
-    [props.mode]
+    [props.mode],
   );
 
   // Window-level pointer move/up for drag detection and box-select
@@ -1373,10 +1470,7 @@ export function ViewportCanvas(props: ViewportProps) {
           return;
         }
         props.onEscape();
-      } else if (
-        (e.key === "Delete" || e.key === "Backspace") &&
-        props.selectedPartIds.size > 0
-      ) {
+      } else if ((e.key === "Delete" || e.key === "Backspace") && props.selectedPartIds.size > 0) {
         props.onDeleteSelected();
       } else if (dragState) {
         const rotateDrag = (axis: 0 | 1 | 2) => {
@@ -1385,9 +1479,15 @@ export function ViewportCanvas(props: ViewportProps) {
           setDragState({ ...dragState, rotation: next });
         };
         switch (e.key.toLowerCase()) {
-          case "r": rotateDrag(1); break;
-          case "f": rotateDrag(2); break;
-          case "t": rotateDrag(0); break;
+          case "r":
+            rotateDrag(1);
+            break;
+          case "f":
+            rotateDrag(2);
+            break;
+          case "t":
+            rotateDrag(0);
+            break;
           case "o": {
             const def = getPartDefinition(dragState.definitionId);
             if (def?.category === "support") {
@@ -1396,42 +1496,97 @@ export function ViewportCanvas(props: ViewportProps) {
             }
             break;
           }
-          case "w": setYLift((prev) => prev + 1); break;
-          case "s": setYLift((prev) => Math.max(0, prev - 1)); break;
+          case "w":
+            setYLift((prev) => prev + 1);
+            break;
+          case "s":
+            setYLift((prev) => Math.max(0, prev - 1));
+            break;
         }
       } else if (props.mode.type === "select" && props.selectedPartIds.size > 0) {
         // Arrow key nudge, W/S lift, and R/T/F/O rotation for selected parts
         const fine = e.shiftKey ? 0.05 : 1;
         switch (e.key) {
-          case "ArrowLeft": e.preventDefault(); props.onNudgeParts(-fine, 0, 0); break;
-          case "ArrowRight": e.preventDefault(); props.onNudgeParts(fine, 0, 0); break;
-          case "ArrowUp": e.preventDefault(); props.onNudgeParts(0, 0, -fine); break;
-          case "ArrowDown": e.preventDefault(); props.onNudgeParts(0, 0, fine); break;
-          case "w": case "W": props.onNudgeParts(0, fine, 0); break;
-          case "s": case "S": props.onNudgeParts(0, -fine, 0); break;
-          case "r": case "R": props.onRotateSelectedParts(1); break;
-          case "t": case "T": props.onRotateSelectedParts(0); break;
-          case "f": case "F": props.onRotateSelectedParts(2); break;
-          case "o": case "O": props.onOrientSelectedParts(); break;
+          case "ArrowLeft":
+            e.preventDefault();
+            props.onNudgeParts(-fine, 0, 0);
+            break;
+          case "ArrowRight":
+            e.preventDefault();
+            props.onNudgeParts(fine, 0, 0);
+            break;
+          case "ArrowUp":
+            e.preventDefault();
+            props.onNudgeParts(0, 0, -fine);
+            break;
+          case "ArrowDown":
+            e.preventDefault();
+            props.onNudgeParts(0, 0, fine);
+            break;
+          case "w":
+          case "W":
+            props.onNudgeParts(0, fine, 0);
+            break;
+          case "s":
+          case "S":
+            props.onNudgeParts(0, -fine, 0);
+            break;
+          case "r":
+          case "R":
+            props.onRotateSelectedParts(1);
+            break;
+          case "t":
+          case "T":
+            props.onRotateSelectedParts(0);
+            break;
+          case "f":
+          case "F":
+            props.onRotateSelectedParts(2);
+            break;
+          case "o":
+          case "O":
+            props.onOrientSelectedParts();
+            break;
         }
       } else if (props.mode.type === "place" || props.mode.type === "paste") {
         switch (e.key.toLowerCase()) {
-          case "r": rotateAxis(1); break;
-          case "f": rotateAxis(2); break;
-          case "t": rotateAxis(0); break;
+          case "r":
+            rotateAxis(1);
+            break;
+          case "f":
+            rotateAxis(2);
+            break;
+          case "t":
+            rotateAxis(0);
+            break;
           case "o":
             if (isPlacingSupport) {
               setGhostOrientation((prev) => nextOrientation(prev));
             }
             break;
-          case "w": setYLift((prev) => prev + 1); break;
-          case "s": setYLift((prev) => Math.max(0, prev - 1)); break;
+          case "w":
+            setYLift((prev) => prev + 1);
+            break;
+          case "s":
+            setYLift((prev) => Math.max(0, prev - 1));
+            break;
         }
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [props.onEscape, props.onDeleteSelected, props.onNudgeParts, props.onRotateSelectedParts, props.onOrientSelectedParts, props.selectedPartIds, props.mode, isPlacingSupport, rotateAxis, dragState]);
+  }, [
+    props.onEscape,
+    props.onDeleteSelected,
+    props.onNudgeParts,
+    props.onRotateSelectedParts,
+    props.onOrientSelectedParts,
+    props.selectedPartIds,
+    props.mode,
+    isPlacingSupport,
+    rotateAxis,
+    dragState,
+  ]);
 
   // Start box-select on shift+pointerdown on empty space
   const handleViewportPointerDown = useCallback(
@@ -1442,22 +1597,24 @@ export function ViewportCanvas(props: ViewportProps) {
       if (pendingDragRef.current) return;
       boxSelectRef.current = { startX: e.clientX, startY: e.clientY };
     },
-    [props.mode]
+    [props.mode],
   );
 
   // Hint text
   let hintText: string | null = null;
   if (dragState) {
     const dragDef = getPartDefinition(dragState.definitionId);
-    hintText = dragDef?.category === "support"
-      ? "T(X) R(Y) F(Z) rotate · O orientation · W/S raise/lower · Release to place · Esc cancel"
-      : "T(X) R(Y) F(Z) rotate · W/S raise/lower · Release to place · Esc cancel";
+    hintText =
+      dragDef?.category === "support"
+        ? "T(X) R(Y) F(Z) rotate · O orientation · W/S raise/lower · Release to place · Esc cancel"
+        : "T(X) R(Y) F(Z) rotate · W/S raise/lower · Release to place · Esc cancel";
   } else if (props.mode.type === "place") {
     hintText = isPlacingSupport
       ? "Click to place · T(X) R(Y) F(Z) rotate · O orientation · W/S raise/lower · Esc cancel"
       : "Click to place · T(X) R(Y) F(Z) rotate · W/S raise/lower · Esc cancel";
   } else if (props.mode.type === "select" && props.selectedPartIds.size > 0) {
-    hintText = "Arrow keys nudge · Shift+arrow fine nudge · w/s up and down - ctrl-c/v copy/paste - Del delete · Esc deselect";
+    hintText =
+      "Arrow keys nudge · Shift+arrow fine nudge · w/s up and down - ctrl-c/v copy/paste - Del delete · Esc deselect";
   } else if (props.mode.type === "paste") {
     hintText = `Click to paste ${props.mode.clipboard.parts.length} part(s) · T(X) R(Y) F(Z) rotate · Esc cancel`;
   }
@@ -1498,16 +1655,8 @@ export function ViewportCanvas(props: ViewportProps) {
           }}
         />
       )}
-      {hintText && (
-        <div className="viewport-hint">
-          {hintText}
-        </div>
-      )}
-      {computingCollisions && (
-        <div className="collision-computing-indicator">
-          Computing collisions...
-        </div>
-      )}
+      {hintText && <div className="viewport-hint">{hintText}</div>}
+      {computingCollisions && <div className="collision-computing-indicator">Computing collisions...</div>}
     </div>
   );
 }

--- a/configurator/src/constants.ts
+++ b/configurator/src/constants.ts
@@ -36,14 +36,14 @@ export const GRID_MAJOR_COLOR = "#666666";
 
 // Part colors for the 3D viewer
 export const PART_COLORS = {
-  support: "#f7b600",    // HR_YELLOW
-  connector: "#2196f3",  // HR_BLUE (brightened for dark UI contrast)
-  lockpin: "#c41e3a",    // HR_RED
+  support: "#f7b600", // HR_YELLOW
+  connector: "#2196f3", // HR_BLUE (brightened for dark UI contrast)
+  lockpin: "#c41e3a", // HR_RED
   ghost_valid: "#44ff44",
   ghost_invalid: "#ff4444",
   ghost_snapped: "#00ffcc",
   selected: "#00aaff",
-  other: "#4a9e4a",      // HR_GREEN (misc/other parts)
+  other: "#4a9e4a", // HR_GREEN (misc/other parts)
   custom: "#6b3a7d",
   collision: "#ff0000",
 } as const;

--- a/configurator/src/data/catalog.ts
+++ b/configurator/src/data/catalog.ts
@@ -35,18 +35,12 @@ function supportDef(units: number): PartDefinition {
 }
 
 /** Generate a connector part definition */
-function connectorDef(
-  configId: string,
-  isFoot: boolean = false,
-  pullThroughAxis?: "x" | "y" | "z"
-): PartDefinition {
+function connectorDef(configId: string, isFoot: boolean = false, pullThroughAxis?: "x" | "y" | "z"): PartDefinition {
   const footSuffix = isFoot ? "-foot" : "";
   const ptSuffix = pullThroughAxis ? `-pt-${pullThroughAxis}` : "";
   const config = CONNECTOR_CONFIGS[configId];
   const footLabel = isFoot ? " Foot" : "";
-  const ptLabel = pullThroughAxis
-    ? ` PT-${pullThroughAxis.toUpperCase()}`
-    : "";
+  const ptLabel = pullThroughAxis ? ` PT-${pullThroughAxis.toUpperCase()}` : "";
 
   return {
     id: `connector-${configId}${footSuffix}${ptSuffix}`,
@@ -68,7 +62,7 @@ export const PART_CATALOG: PartDefinition[] = [
   // Connectors — generated from model manifest
   ...modelManifest.connectors.map((c) => {
     const configId = `${c.params.dimensions}d${c.params.directions}w`;
-    const pt = c.params.pull_through_axis !== "none" ? c.params.pull_through_axis as "x" | "y" | "z" : undefined;
+    const pt = c.params.pull_through_axis !== "none" ? (c.params.pull_through_axis as "x" | "y" | "z") : undefined;
     return connectorDef(configId, c.params.is_foot, pt);
   }),
 
@@ -93,16 +87,25 @@ export const PART_CATALOG: PartDefinition[] = [
   },
 
   // Other — raw models converted from raw-models/ directory
-  ...(rawModelsManifest as Array<{ id: string; name: string; file: string; group?: string }>).map((entry): PartDefinition => ({
-    id: entry.id,
-    category: "other",
-    name: entry.name,
-    description: entry.group ? `${entry.group} — ${entry.name}` : entry.name,
-    modelPath: `models/${entry.file}`,
-    connectionPoints: [],
-    gridCells: [[0, 0, 0]],
-    ...(entry.group ? { group: entry.group } : {}),
-  })),
+  ...(
+    rawModelsManifest as Array<{
+      id: string;
+      name: string;
+      file: string;
+      group?: string;
+    }>
+  ).map(
+    (entry): PartDefinition => ({
+      id: entry.id,
+      category: "other",
+      name: entry.name,
+      description: entry.group ? `${entry.group} — ${entry.name}` : entry.name,
+      modelPath: `models/${entry.file}`,
+      connectionPoints: [],
+      gridCells: [[0, 0, 0]],
+      ...(entry.group ? { group: entry.group } : {}),
+    }),
+  ),
 ];
 
 /** Look up a part definition by ID (checks built-in catalog, then custom parts) */
@@ -111,9 +114,7 @@ export function getPartDefinition(id: string): PartDefinition | undefined {
 }
 
 /** Get parts filtered by category */
-export function getPartsByCategory(
-  category: PartDefinition["category"]
-): PartDefinition[] {
+export function getPartsByCategory(category: PartDefinition["category"]): PartDefinition[] {
   if (category === "custom") return getCustomParts();
   return PART_CATALOG.filter((p) => p.category === category);
 }

--- a/configurator/src/data/connector-configs.ts
+++ b/configurator/src/data/connector-configs.ts
@@ -18,19 +18,55 @@ interface ConnectorConfig {
 
 export const CONNECTOR_CONFIGS: Record<string, ConnectorConfig> = {
   // 1D configurations (Z-axis only — vertical in OpenSCAD, depth in Three.js)
-  "1d1w": { dimensions: 1, directions: 1, arms: [true, false, false, false, false, false] },
-  "1d2w": { dimensions: 1, directions: 2, arms: [true, true, false, false, false, false] },
+  "1d1w": {
+    dimensions: 1,
+    directions: 1,
+    arms: [true, false, false, false, false, false],
+  },
+  "1d2w": {
+    dimensions: 1,
+    directions: 2,
+    arms: [true, true, false, false, false, false],
+  },
 
   // 2D configurations (Z + X axes — flat on XZ ground plane)
-  "2d2w": { dimensions: 2, directions: 2, arms: [true, false, true, false, false, false] },
-  "2d3w": { dimensions: 2, directions: 3, arms: [true, true, true, false, false, false] },
-  "2d4w": { dimensions: 2, directions: 4, arms: [true, true, true, true, false, false] },
+  "2d2w": {
+    dimensions: 2,
+    directions: 2,
+    arms: [true, false, true, false, false, false],
+  },
+  "2d3w": {
+    dimensions: 2,
+    directions: 3,
+    arms: [true, true, true, false, false, false],
+  },
+  "2d4w": {
+    dimensions: 2,
+    directions: 4,
+    arms: [true, true, true, true, false, false],
+  },
 
   // 3D configurations (all three axes)
-  "3d3w": { dimensions: 3, directions: 3, arms: [true, false, true, false, true, false] },
-  "3d4w": { dimensions: 3, directions: 4, arms: [true, true, true, false, true, false] },
-  "3d5w": { dimensions: 3, directions: 5, arms: [true, true, true, true, true, false] },
-  "3d6w": { dimensions: 3, directions: 6, arms: [true, true, true, true, true, true] },
+  "3d3w": {
+    dimensions: 3,
+    directions: 3,
+    arms: [true, false, true, false, true, false],
+  },
+  "3d4w": {
+    dimensions: 3,
+    directions: 4,
+    arms: [true, true, true, false, true, false],
+  },
+  "3d5w": {
+    dimensions: 3,
+    directions: 5,
+    arms: [true, true, true, true, true, false],
+  },
+  "3d6w": {
+    dimensions: 3,
+    directions: 6,
+    arms: [true, true, true, true, true, true],
+  },
 };
 
 // Identity mapping: arms array index → direction (no axis conversion needed)
@@ -40,7 +76,5 @@ const DIRECTION_MAP: Direction[] = ["+z", "-z", "+x", "-x", "+y", "-y"];
 export function getArmDirections(configId: string): Direction[] {
   const config = CONNECTOR_CONFIGS[configId];
   if (!config) return [];
-  return config.arms
-    .map((active, i) => (active ? DIRECTION_MAP[i] : null))
-    .filter((d): d is Direction => d !== null);
+  return config.arms.map((active, i) => (active ? DIRECTION_MAP[i] : null)).filter((d): d is Direction => d !== null);
 }

--- a/configurator/src/data/custom-parts.ts
+++ b/configurator/src/data/custom-parts.ts
@@ -37,7 +37,7 @@ function persistMeta() {
     id: d.id,
     name: d.name,
     gridCells: d.gridCells,
-    format: d.id.startsWith("custom-3mf-") ? "3mf" as const : "stl" as const,
+    format: d.id.startsWith("custom-3mf-") ? ("3mf" as const) : ("stl" as const),
   }));
   saveCustomPartsMeta(meta);
 }
@@ -96,9 +96,7 @@ export async function downloadCustomPart(defId: string): Promise<void> {
 
 /** Delete all custom parts whose IDs are not in the given set of used definition IDs */
 export async function deleteUnusedCustomParts(usedDefinitionIds: Set<string>): Promise<void> {
-  const toDelete = customDefinitions
-    .filter((d) => !usedDefinitionIds.has(d.id))
-    .map((d) => d.id);
+  const toDelete = customDefinitions.filter((d) => !usedDefinitionIds.has(d.id)).map((d) => d.id);
   for (const id of toDelete) {
     await deleteCustomPart(id);
   }
@@ -158,7 +156,11 @@ export async function deleteCustomPart(defId: string): Promise<void> {
   }
   notify();
   persistMeta();
-  try { await deleteSTLBuffer(defId); } catch { /* ignore */ }
+  try {
+    await deleteSTLBuffer(defId);
+  } catch {
+    /* ignore */
+  }
 }
 
 let nextId = 1;
@@ -232,7 +234,11 @@ type ModelFormat = "stl" | "3mf";
  */
 function parse3MFModelXml(xml: string): { objectId: string; name?: string; geometry: THREE.BufferGeometry }[] {
   const doc = new DOMParser().parseFromString(xml, "application/xml");
-  const results: { objectId: string; name?: string; geometry: THREE.BufferGeometry }[] = [];
+  const results: {
+    objectId: string;
+    name?: string;
+    geometry: THREE.BufferGeometry;
+  }[] = [];
 
   const objects = doc.querySelectorAll("object");
   for (const obj of objects) {
@@ -310,7 +316,10 @@ function parse3MF(buffer: ArrayBuffer): { geometry: THREE.BufferGeometry; name?:
 
   if (!rootModelPath || !zip[rootModelPath]) {
     // No rels — just return all mesh objects found
-    return [...allObjects.values()].map((o) => ({ geometry: o.geometry, name: o.name }));
+    return [...allObjects.values()].map((o) => ({
+      geometry: o.geometry,
+      name: o.name,
+    }));
   }
 
   const rootXml = decoder.decode(zip[rootModelPath]);
@@ -320,7 +329,10 @@ function parse3MF(buffer: ArrayBuffer): { geometry: THREE.BufferGeometry; name?:
   const buildItems = rootDoc.querySelectorAll("build > item");
   if (buildItems.length === 0) {
     // No build section — return all mesh objects
-    return [...allObjects.values()].map((o) => ({ geometry: o.geometry, name: o.name }));
+    return [...allObjects.values()].map((o) => ({
+      geometry: o.geometry,
+      name: o.name,
+    }));
   }
 
   const results: { geometry: THREE.BufferGeometry; name?: string }[] = [];
@@ -341,16 +353,19 @@ function parse3MF(buffer: ArrayBuffer): { geometry: THREE.BufferGeometry; name?:
     const directKey = `${rootModelPath}:${objectId}`;
     if (allObjects.has(directKey)) {
       const entry = allObjects.get(directKey)!;
-      results.push({ geometry: entry.geometry, name: rootObjName ?? entry.name });
+      results.push({
+        geometry: entry.geometry,
+        name: rootObjName ?? entry.name,
+      });
       continue;
     }
 
     // Composite with p:path references?
     const components = obj.querySelectorAll("components > component");
     for (const comp of components) {
-      const pPath = comp.getAttribute("p:path") ?? comp.getAttributeNS(
-        "http://schemas.microsoft.com/3dmanufacturing/production/2015/06", "path"
-      );
+      const pPath =
+        comp.getAttribute("p:path") ??
+        comp.getAttributeNS("http://schemas.microsoft.com/3dmanufacturing/production/2015/06", "path");
       const compObjectId = comp.getAttribute("objectid");
       if (!compObjectId) continue;
 
@@ -359,19 +374,30 @@ function parse3MF(buffer: ArrayBuffer): { geometry: THREE.BufferGeometry; name?:
         const resolvedPath = pPath.startsWith("/") ? pPath.substring(1) : pPath;
         const key = `${resolvedPath}:${compObjectId}`;
         const entry = allObjects.get(key);
-        if (entry) results.push({ geometry: entry.geometry, name: rootObjName ?? entry.name });
+        if (entry)
+          results.push({
+            geometry: entry.geometry,
+            name: rootObjName ?? entry.name,
+          });
       } else {
         // Same-model reference
         const key = `${rootModelPath}:${compObjectId}`;
         const entry = allObjects.get(key);
-        if (entry) results.push({ geometry: entry.geometry, name: rootObjName ?? entry.name });
+        if (entry)
+          results.push({
+            geometry: entry.geometry,
+            name: rootObjName ?? entry.name,
+          });
       }
     }
   }
 
   if (results.length === 0) {
     // Fallback: return all mesh objects found in any model file
-    return [...allObjects.values()].map((o) => ({ geometry: o.geometry, name: o.name }));
+    return [...allObjects.values()].map((o) => ({
+      geometry: o.geometry,
+      name: o.name,
+    }));
   }
 
   return results;
@@ -452,7 +478,9 @@ export function importModelFile(file: File): Promise<PartDefinition[]> {
             const objName = parts[i].name;
             const partLabel = objName
               ? `${baseName} - ${objName}`
-              : parts.length === 1 ? baseName : `${baseName} (${i + 1})`;
+              : parts.length === 1
+                ? baseName
+                : `${baseName} (${i + 1})`;
             const def = await registerCustomPart(partLabel, format, parts[i].geometry, buffer);
             defs.push(def);
           }
@@ -490,8 +518,7 @@ export async function restoreCustomParts(): Promise<void> {
     if (!buffer) continue; // Binary lost — skip this part
 
     try {
-      const format: ModelFormat =
-        entry.format ?? (entry.id.startsWith("custom-3mf-") ? "3mf" : "stl");
+      const format: ModelFormat = entry.format ?? (entry.id.startsWith("custom-3mf-") ? "3mf" : "stl");
       const geometry = parseStoredBuffer(buffer, format);
 
       // Re-voxelize from actual geometry (fixes stale bounding-box cells from old saves)

--- a/configurator/src/scene/PartLoader.ts
+++ b/configurator/src/scene/PartLoader.ts
@@ -27,7 +27,7 @@ export async function loadModel(path: string): Promise<THREE.Group> {
         (err) => {
           loading.delete(path);
           reject(err);
-        }
+        },
       );
     });
     loading.set(path, promise);

--- a/configurator/src/thumbnails/ThumbnailGenerator.ts
+++ b/configurator/src/thumbnails/ThumbnailGenerator.ts
@@ -32,11 +32,7 @@ function fitCameraToObject(object: THREE.Object3D) {
   const size = box.getSize(new THREE.Vector3());
   const maxDim = Math.max(size.x, size.y, size.z);
   const dist = maxDim * 1.8;
-  camera!.position.set(
-    center.x + dist * 0.7,
-    center.y + dist * 0.5,
-    center.z + dist * 0.7
-  );
+  camera!.position.set(center.x + dist * 0.7, center.y + dist * 0.5, center.z + dist * 0.7);
   camera!.lookAt(center);
   camera!.updateProjectionMatrix();
 }
@@ -74,11 +70,7 @@ export async function generateThumbnail(modelPath: string): Promise<string> {
 }
 
 /** Generate a thumbnail from a BufferGeometry (for custom STL parts). */
-export function generateThumbnailFromGeometry(
-  defId: string,
-  geometry: THREE.BufferGeometry,
-  color: string
-): string {
+export function generateThumbnailFromGeometry(defId: string, geometry: THREE.BufferGeometry, color: string): string {
   if (cache.has(defId)) return cache.get(defId)!;
   ensureRenderer();
   const material = new THREE.MeshStandardMaterial({ color });

--- a/configurator/src/thumbnails/useThumbnail.ts
+++ b/configurator/src/thumbnails/useThumbnail.ts
@@ -1,9 +1,5 @@
 import { useState, useEffect } from "react";
-import {
-  generateThumbnail,
-  generateThumbnailFromGeometry,
-  getCachedThumbnail,
-} from "./ThumbnailGenerator";
+import { generateThumbnail, generateThumbnailFromGeometry, getCachedThumbnail } from "./ThumbnailGenerator";
 import { isCustomPart, getCustomPartGeometry } from "../data/custom-parts";
 import { PART_COLORS } from "../constants";
 import type { PartDefinition } from "../types";
@@ -11,9 +7,7 @@ import type { PartDefinition } from "../types";
 /** React hook that lazily generates and caches a part thumbnail. */
 export function useThumbnail(part: PartDefinition): string | null {
   const key = isCustomPart(part.id) ? part.id : part.modelPath;
-  const [dataURL, setDataURL] = useState<string | null>(() =>
-    getCachedThumbnail(key)
-  );
+  const [dataURL, setDataURL] = useState<string | null>(() => getCachedThumbnail(key));
 
   useEffect(() => {
     if (dataURL) return;
@@ -21,15 +15,13 @@ export function useThumbnail(part: PartDefinition): string | null {
     if (isCustomPart(part.id)) {
       const geometry = getCustomPartGeometry(part.id);
       if (geometry) {
-        const url = generateThumbnailFromGeometry(
-          part.id,
-          geometry,
-          PART_COLORS.custom
-        );
+        const url = generateThumbnailFromGeometry(part.id, geometry, PART_COLORS.custom);
         setDataURL(url);
       }
     } else if (part.modelPath) {
-      generateThumbnail(part.modelPath).then(setDataURL).catch(() => {});
+      generateThumbnail(part.modelPath)
+        .then(setDataURL)
+        .catch(() => {});
     }
   }, [key, part.id, part.modelPath, dataURL]);
 


### PR DESCRIPTION
## Why this PR

This is meant as a lightweight step toward consistent formatting in the `configurator` TS/TSX code.

Main goal: make future PRs easier to review by reducing formatting noise, so diffs focus more on behavior and logic changes.

## What’s included

- Add Biome setup for `configurator`:
  - dependency + config
  - `format` / `format:check` scripts
  - pre-commit formatting check for TS/TSX files
- One dedicated formatting pass across existing TS/TSX files
- `.git-blame-ignore-revs` entry support for the formatting-only commit

## Why it’s split in two commits

1. **Config/setup commit**  
2. **Formatting-only commit**

This keeps tooling changes separate from formatting churn and makes the intent clearer.

## Notes / openness to feedback

This is a starting point, not a rigid rule set.  
If any formatting defaults feel off (line width, spacing, scope, etc.), I’m very open to adjusting them so that we can land on a style that feels practical and comfortable.

The idea here is simply to establish a shared guideline that keeps PRs cleaner over time.


--- 
Not entirely sure if this is the best approach for this kind of changes.