### PR TITLE
ci: add Bun runtime to pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install system dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary

- Add `oven-sh/setup-bun@v2` to the pre-commit GitHub Actions workflow so the runner has the Bun runtime available.

## Why

PR #67 introduces a Biome formatting pre-commit hook that runs `bun run format` inside `configurator/`. Without Bun installed on the runner, the pre-commit job fails because the `bun` command is not found.

Ref: https://github.com/kellerlabs/homeracker-community/pull/67

## Changes

Single-line addition in `.github/workflows/pre-commit.yml` — sets up Bun after Python and before system dependencies, so it's available when pre-commit hooks execute.